### PR TITLE
Cleanup the table installation script

### DIFF
--- a/includes/class-wc-custom-order-table-install.php
+++ b/includes/class-wc-custom-order-table-install.php
@@ -101,6 +101,6 @@ class WC_Custom_Order_Table_Install {
 		dbDelta( $tables );
 
 		// Store the table version in the options table.
-		update_option( self::SCHEMA_VERSION_KEY, (int) self::$table_version );
+		update_option( self::SCHEMA_VERSION_KEY, (int) self::$table_version, false );
 	}
 }

--- a/includes/class-wc-custom-order-table-install.php
+++ b/includes/class-wc-custom-order-table-install.php
@@ -20,39 +20,16 @@ class WC_Custom_Order_Table_Install {
 	 */
 	protected $table_version = 1;
 
-
 	/**
 	 * Actions to perform on plugin activation.
 	 */
 	public function activate() {
-		$this->maybe_install_tables();
-	}
-
-	/**
-	 * Retrieve the latest table schema version.
-	 *
-	 * @return int The latest schema version.
-	 */
-	public function get_latest_table_version() {
-		return absint( $this->table_version );
-	}
-
-	/**
-	 * Retrieve the current table version from the options table.
-	 *
-	 * @return int The current schema version.
-	 */
-	public function get_installed_table_version() {
-		return absint( get_option( self::SCHEMA_VERSION_KEY ) );
-	}
-
-	/**
-	 * Install or update the tables if the site is not using the current schema.
-	 */
-	protected function maybe_install_tables() {
-		if ( $this->get_installed_table_version() < $this->get_latest_table_version() ) {
-			$this->install_tables();
+		// We're already on the latest schema version.
+		if ( (int) $this->table_version === (int) get_option( self::SCHEMA_VERSION_KEY ) ) {
+			return false;
 		}
+
+		$this->install_tables();
 	}
 
 	/**
@@ -124,6 +101,6 @@ class WC_Custom_Order_Table_Install {
 		dbDelta( $tables );
 
 		// Store the table version in the options table.
-		update_option( self::SCHEMA_VERSION_KEY, $this->get_latest_table_version() );
+		update_option( self::SCHEMA_VERSION_KEY, (int) $this->table_version );
 	}
 }

--- a/includes/class-wc-custom-order-table-install.php
+++ b/includes/class-wc-custom-order-table-install.php
@@ -18,14 +18,14 @@ class WC_Custom_Order_Table_Install {
 	 *
 	 * @var int
 	 */
-	protected $table_version = 1;
+	protected static $table_version = 1;
 
 	/**
 	 * Actions to perform on plugin activation.
 	 */
 	public function activate() {
 		// We're already on the latest schema version.
-		if ( (int) $this->table_version === (int) get_option( self::SCHEMA_VERSION_KEY ) ) {
+		if ( (int) self::$table_version === (int) get_option( self::SCHEMA_VERSION_KEY ) ) {
 			return false;
 		}
 
@@ -101,6 +101,6 @@ class WC_Custom_Order_Table_Install {
 		dbDelta( $tables );
 
 		// Store the table version in the options table.
-		update_option( self::SCHEMA_VERSION_KEY, (int) $this->table_version );
+		update_option( self::SCHEMA_VERSION_KEY, (int) self::$table_version );
 	}
 }

--- a/includes/class-wc-custom-order-table-install.php
+++ b/includes/class-wc-custom-order-table-install.php
@@ -23,13 +23,13 @@ class WC_Custom_Order_Table_Install {
 	/**
 	 * Actions to perform on plugin activation.
 	 */
-	public function activate() {
+	public static function activate() {
 		// We're already on the latest schema version.
 		if ( (int) self::$table_version === (int) get_option( self::SCHEMA_VERSION_KEY ) ) {
 			return false;
 		}
 
-		$this->install_tables();
+		self::install_tables();
 	}
 
 	/**
@@ -37,7 +37,7 @@ class WC_Custom_Order_Table_Install {
 	 *
 	 * @global $wpdb
 	 */
-	protected function install_tables() {
+	protected static function install_tables() {
 		global $wpdb;
 
 		// Load wp-admin/includes/upgrade.php, which defines dbDelta().

--- a/includes/class-wc-custom-order-table-install.php
+++ b/includes/class-wc-custom-order-table-install.php
@@ -9,6 +9,11 @@
 class WC_Custom_Order_Table_Install {
 
 	/**
+	 * The option key that contains the current schema version.
+	 */
+	const SCHEMA_VERSION_KEY = 'wc_orders_table_version';
+
+	/**
 	 * The database table schema version.
 	 *
 	 * @var int
@@ -38,7 +43,7 @@ class WC_Custom_Order_Table_Install {
 	 * @return int The current schema version.
 	 */
 	public function get_installed_table_version() {
-		return absint( get_option( 'wc_orders_table_version' ) );
+		return absint( get_option( self::SCHEMA_VERSION_KEY ) );
 	}
 
 	/**
@@ -119,6 +124,6 @@ class WC_Custom_Order_Table_Install {
 		dbDelta( $tables );
 
 		// Store the table version in the options table.
-		update_option( 'wc_orders_table_version', $this->get_latest_table_version() );
+		update_option( self::SCHEMA_VERSION_KEY, $this->get_latest_table_version() );
 	}
 }

--- a/includes/class-wc-custom-order-table-install.php
+++ b/includes/class-wc-custom-order-table-install.php
@@ -43,14 +43,9 @@ class WC_Custom_Order_Table_Install {
 		// Load wp-admin/includes/upgrade.php, which defines dbDelta().
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-		$collate = '';
-
-		if ( $wpdb->has_cap( 'collation' ) ) {
-			$collate = $wpdb->get_charset_collate();
-		}
-
-		$table  = wc_custom_order_table()->get_table_name();
-		$tables = "
+		$table   = wc_custom_order_table()->get_table_name();
+		$collate = $wpdb->get_charset_collate();
+		$tables  = "
 			CREATE TABLE {$table} (
 				order_id BIGINT UNSIGNED NOT NULL,
 				order_key varchar(100) NOT NULL,

--- a/tests/test-installation.php
+++ b/tests/test-installation.php
@@ -49,8 +49,7 @@ class InstallationTest extends TestCase {
 			'The wp_woocommerce_orders table should not exist at the beginning of this test.'
 		);
 
-		$instance = new WC_Custom_Order_Table_Install();
-		$instance->activate();
+		WC_Custom_Order_Table_Install::activate();
 
 		$this->assertTrue(
 			self::orders_table_exists(),
@@ -63,27 +62,25 @@ class InstallationTest extends TestCase {
 	}
 
 	public function test_returns_early_if_already_on_latest_schema_version() {
-		$instance = new WC_Custom_Order_Table_Install();
-		$instance->activate();
+		WC_Custom_Order_Table_Install::activate();
 
 		$this->assertFalse(
-			$instance->activate(),
+			WC_Custom_Order_Table_Install::activate(),
 			'The activate() method should return false if the schema versions match.'
 		);
 	}
 
 	public function test_can_upgrade_table() {
-		$instance = new WC_Custom_Order_Table_Install();
-		$instance->activate();
+		WC_Custom_Order_Table_Install::activate();
 
 		// Get the current schema version, then increment it.
-		$property = new ReflectionProperty( $instance, 'table_version' );
+		$property = new ReflectionProperty( 'WC_Custom_Order_Table_Install', 'table_version' );
 		$property->setAccessible( true );
-		$version  = $property->getValue( $instance );
-		$property->setValue( $instance, $version + 1 );
+		$version  = $property->getValue();
+		$property->setValue( $version + 1 );
 
 		// Run the activation script again.
-		$instance->activate();
+		WC_Custom_Order_Table_Install::activate();
 
 		$this->assertEquals(
 			$version + 1,

--- a/tests/test-installation.php
+++ b/tests/test-installation.php
@@ -25,4 +25,60 @@ class InstallationTest extends TestCase {
 			'Upon activation, the table should be created.'
 		);
 	}
+
+	public function test_table_is_only_installed_if_it_does_not_already_exist() {
+		self::reactivate_plugin();
+
+		$this->assertTrue(
+			self::orders_table_exists(),
+			'Upon activation, the table should be created.'
+		);
+
+		// Deactivate, then re-activate the plugin.
+		self::reactivate_plugin();
+
+		$this->assertTrue(
+			self::orders_table_exists(),
+			'The table should still exist, just as it was.'
+		);
+	}
+
+	public function test_can_install_table() {
+		$this->assertFalse(
+			self::orders_table_exists(),
+			'The wp_woocommerce_orders table should not exist at the beginning of this test.'
+		);
+
+		$instance = new WC_Custom_Order_Table_Install();
+		$instance->activate();
+
+		$this->assertTrue(
+			self::orders_table_exists(),
+			'Upon activation, the table should be created.'
+		);
+		$this->assertNotEmpty(
+			get_option( 'wc_orders_table_version' ),
+			'The schema version should be stored in the options table.'
+		);
+	}
+
+	public function test_can_upgrade_table() {
+		$instance = new WC_Custom_Order_Table_Install();
+		$instance->activate();
+
+		// Get the current schema version, then increment it.
+		$property = new ReflectionProperty( $instance, 'table_version' );
+		$property->setAccessible( true );
+		$version  = $property->getValue( $instance );
+		$property->setValue( $instance, $version + 1 );
+
+		// Run the activation script again.
+		$instance->activate();
+
+		$this->assertEquals(
+			$version + 1,
+			get_option( 'wc_orders_table_version' ),
+			'The schema version should have been incremented.'
+		);
+	}
 }

--- a/tests/test-installation.php
+++ b/tests/test-installation.php
@@ -57,7 +57,7 @@ class InstallationTest extends TestCase {
 			'Upon activation, the table should be created.'
 		);
 		$this->assertNotEmpty(
-			get_option( 'wc_orders_table_version' ),
+			get_option( WC_Custom_Order_Table_Install::SCHEMA_VERSION_KEY ),
 			'The schema version should be stored in the options table.'
 		);
 	}
@@ -77,7 +77,7 @@ class InstallationTest extends TestCase {
 
 		$this->assertEquals(
 			$version + 1,
-			get_option( 'wc_orders_table_version' ),
+			get_option( WC_Custom_Order_Table_Install::SCHEMA_VERSION_KEY ),
 			'The schema version should have been incremented.'
 		);
 	}

--- a/tests/test-installation.php
+++ b/tests/test-installation.php
@@ -62,6 +62,16 @@ class InstallationTest extends TestCase {
 		);
 	}
 
+	public function test_returns_early_if_already_on_latest_schema_version() {
+		$instance = new WC_Custom_Order_Table_Install();
+		$instance->activate();
+
+		$this->assertFalse(
+			$instance->activate(),
+			'The activate() method should return false if the schema versions match.'
+		);
+	}
+
 	public function test_can_upgrade_table() {
 		$instance = new WC_Custom_Order_Table_Install();
 		$instance->activate();

--- a/tests/test-installation.php
+++ b/tests/test-installation.php
@@ -88,4 +88,19 @@ class InstallationTest extends TestCase {
 			'The schema version should have been incremented.'
 		);
 	}
+
+	public function test_current_schema_version_is_not_autoloaded() {
+		global $wpdb;
+
+		WC_Custom_Order_Table_Install::activate();
+
+		$this->assertEquals(
+			'no',
+			$wpdb->get_var( $wpdb->prepare(
+				"SELECT autoload FROM $wpdb->options WHERE option_name = %s LIMIT 1",
+				WC_Custom_Order_Table_Install::SCHEMA_VERSION_KEY
+			) ),
+			'The schema version should not be autoloaded.'
+		);
+	}
 }

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -32,7 +32,7 @@ class TestCase extends WP_UnitTestCase {
 
 		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_orders" );
 
-		delete_option( 'wc_orders_table_version' );
+		delete_option( WC_Custom_Order_Table_Install::SCHEMA_VERSION_KEY );
 	}
 
 	/**

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -31,6 +31,8 @@ class TestCase extends WP_UnitTestCase {
 		global $wpdb;
 
 		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}woocommerce_orders" );
+
+		delete_option( 'wc_orders_table_version' );
 	}
 
 	/**

--- a/wc-custom-order-table.php
+++ b/wc-custom-order-table.php
@@ -26,16 +26,9 @@ if ( file_exists( WC_CUSTOM_ORDER_TABLE_PATH . 'vendor/autoload_52.php' ) ) {
 }
 
 /**
- * Installation procedure for the plugin.
- *
- * This function is responsible for creating the new plugin database tables.
+ * Install the database tables upon plugin activation.
  */
-function wc_custom_order_table_install() {
-	$installer = new WC_Custom_Order_Table_Install();
-	$installer->activate();
-}
-
-register_activation_hook( __FILE__, 'wc_custom_order_table_install' );
+register_activation_hook( __FILE__, array( 'WC_Custom_Order_Table_Install', 'activate' ) );
 
 /**
  * Retrieve an instance of the WC_Custom_Order_Table class.


### PR DESCRIPTION
This PR rewrites the `WC_Custom_Order_Table_Install` to use just two static methods: `activate()` (which performs the jobs formerly handled by `maybe_install_tables()`, `get_latest_table_version()`, and `get_installed_table_version()`), and `install_tables()`, the latter of which is marked as protected.

This enables `register_activation_hook()` to call `WC_Custom_Order_Table_Install::activate()` directly, while avoiding treating the installer as an object (since it's really just using the class construct as a pseudo-namespace).

The PR also ensures that the "wc_orders_table_version" option is not auto-loaded, as it's _only_ needed during plugin activation.