### PR TITLE
Add contributing + changelog docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Version 1.0.0 (Beta 2)] - 2017-12-22
+
+* Clean up codebase to adhere to the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/), and introduce an `.editorconfig` to make this kind of change less likely in the future ([#8])
+* Introduced automated unit tests via the WordPress core test suite ([#9])
+* Fixed bug where custom database table was not being created upon plugin activation ([#5], [#9])
+* General documentation updates ([#2])
+
+## [Version 1.0.0 (Beta 1)] - 2017-10-02
+
+* Initial public release of the plugin in a beta state.
+
+
+[Unreleased]: https://github.com/liquidweb/woocommerce-order-tables/compare/master...develop
+[Version 1.0.0 (Beta 2)]: https://github.com/liquidweb/woocommerce-order-tables/releases/tag/v1.0.0-beta.2
+[Version 1.0.0 (Beta 1)]: https://github.com/liquidweb/woocommerce-order-tables/releases/tag/v1.0.0-beta.1
+[#2]: https://github.com/liquidweb/woocommerce-order-tables/pull/2
+[#5]: https://github.com/liquidweb/woocommerce-order-tables/pull/5
+[#8]: https://github.com/liquidweb/woocommerce-order-tables/pull/8
+[#9]: https://github.com/liquidweb/woocommerce-order-tables/pull/9

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to WooCommerce Custom Order Tables
+
+Thank you for your interest in WooCommerce Custom Order Tables!
+
+
+## Reporting bugs and/or suggesting new features
+
+We welcome input from the community on new features for the plugin, as well as reports of anything that doesn't seem to be working properly.
+
+To make a suggestion or report a bug, please [create a new issue within the GitHub repository](https://github.com/liquidweb/woocommerce-order-tables/issues/new) with a descriptive title and as much pertinent information as possible.
+
+When reporting a bug, please include the following information:
+
+* Steps to reproduce (what steps would someone need to take to see the bug in action?)
+* The expected behavior (what _should_ happen?)
+* The observed behavior (what _is_ happening?)
+* Information about your WooCommerce instance — this can easily be obtained via the WooCommerce &rsaquo; Status screen, via the "Get system report" button at the top of that page.
+
+
+## Contributing code
+
+If you're interested in contributing to the plugin by way of code and/or documentation, please read the following details about the structure of the project:
+
+
+### Coding conventions
+
+This project adheres to the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/), and [an `.editorconfig` file](http://editorconfig.org/) is included in the repository to help most <abbr title="Integrated Development Environment">IDE</abbr>s adjust accordingly.
+
+
+### Branching strategy
+
+This project uses [Gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) as a branching strategy:
+
+* `develop` represents the current development version, whereas `master` represents the latest stable release.
+* All work should be done in separate feature branches, which should be branched from `develop`.
+
+
+#### Tagging a new release
+
+When a new release is being prepared, a new `release/vX.X.X` branch will be created from `develop`, version numbers bumped and any last-minute release adjustments made, then the release branch will be merged (via non-fast-forward merge) into `master`.
+
+Once master has been updated, the release should be tagged, then `master` should be merged into `develop`.
+
+
+### Unit testing
+
+WooCommerce Custom Order Tables uses [the WordPress core testing suite](https://make.wordpress.org/core/handbook/testing/automated-testing/writing-phpunit-tests/) to provide automated tests for its functionality.
+
+When submitting pull requests, please include relevant tests for your new features and bugfixes. This helps prevent regressions in future iterations of the plugin, and helps instill confidence in store owners using this to enhance their WooCommerce stores.

--- a/wc-custom-order-table.php
+++ b/wc-custom-order-table.php
@@ -3,7 +3,7 @@
  * Plugin Name:          WooCommerce - Custom Order Tables
  * Plugin URI:           https://github.com/liquidweb/WooCommerce-Order-Tables
  * Description:          Store WooCommerce order data in a custom table.
- * Version:              1.0.1
+ * Version:              1.0.0
  * Author:               Liquid Web
  * Author URI:           https://www.liquidweb.com
  * License:              GPL2


### PR DESCRIPTION
This pull request introduces two new files:

1. `CHANGELOG.md` tracks changes as they're made between releases (I've retroactively added a changeset for 1.0.0 Betas 1 to 2), based on the [Keep a Changelog standard](http://keepachangelog.com/en/1.0.0/).
2. `CONTRIBUTING.md` covers coding standards, branching strategies, and issue reporting to help contributors (from within Liquid Web or beyond) collaborate effectively on the plugin.

After adjusting the `v1.0.1-beta.2` tag that was pushed out Friday evening, this PR also restores the version number in the plugin header to "1.0.0" — on the next and subsequent beta releases, we'll bump this to "1.0.0 (Beta X)", and finally come back to 1.0.0 when we release the first official version.