### PR TITLE
Add indexes for the existing wp_woocommerce_orders table schema.

### DIFF
--- a/includes/class-wc-custom-order-table-install.php
+++ b/includes/class-wc-custom-order-table-install.php
@@ -18,7 +18,7 @@ class WC_Custom_Order_Table_Install {
 	 *
 	 * @var int
 	 */
-	protected static $table_version = 1;
+	protected static $table_version = 2;
 
 	/**
 	 * Actions to perform on plugin activation.
@@ -88,7 +88,10 @@ class WC_Custom_Order_Table_Install {
 				date_completed datetime DEFAULT NULL,
 				date_paid datetime DEFAULT NULL,
 				cart_hash varchar(32) NOT NULL,
-			PRIMARY KEY  (order_id)
+			PRIMARY KEY  (order_id),
+			UNIQUE KEY `order_key` (`order_key`),
+			KEY `customer_id` (`customer_id`),
+			KEY `order_total` (`total`)
 			) $collate;
 		";
 

--- a/tests/test-installation.php
+++ b/tests/test-installation.php
@@ -103,4 +103,60 @@ class InstallationTest extends TestCase {
 			'The schema version should not be autoloaded.'
 		);
 	}
+
+	/**
+	 * Test that the generated database schema contains the expected indexes.
+	 *
+	 * @dataProvider table_index_provider()
+	 */
+	public function test_database_indexes( $non_unique, $key_name, $column_name ) {
+		global $wpdb;
+
+		WC_Custom_Order_Table_Install::activate();
+
+		$table   = wc_custom_order_table()->get_table_name();
+		$indexes = $wpdb->get_results( "SHOW INDEX FROM $table", ARRAY_A );
+		$search  = array(
+			'Non_unique'  => $non_unique,
+			'Key_name'    => $key_name,
+			'Column_name' => $column_name,
+		);
+
+		// Find the index by name.
+		foreach ( $indexes as $index ) {
+			if ( $index['Key_name'] !== $key_name ) {
+				continue;
+			}
+
+			$this->assertEquals(
+				$non_unique,
+				$index['Non_unique'],
+				sprintf(
+					'Did not match expected non-uniqueness (Received %d, expected %d',
+					$non_unique,
+					$index['Non_unique']
+				)
+			);
+
+			$this->assertEquals(
+				$column_name,
+				$index['Column_name'],
+				sprintf( 'Expected index "%s" on column %s.', $key_name, $column_name )
+			);
+
+			// We've checked the index we've come to check, return early.
+			return;
+		}
+
+		$this->fail( sprintf( 'Could not find an index with name "%s".', $key_name ) );
+	}
+
+	public function table_index_provider() {
+		return array(
+			'Primary key' => array( 0, 'PRIMARY', 'order_id' ),
+			'Order key'   => array( 0, 'order_key', 'order_key' ),
+			'Customer ID' => array( 1, 'customer_id', 'customer_id' ),
+			'Order total' => array( 1, 'order_total', 'total' ),
+		);
+	}
 }


### PR DESCRIPTION
This PR adds indexes to the following columns in the existing schema, along with corresponding tests:

* order_key (unique) - used to identify the order within WooCommerce.
* customer_id - the WordPress user ID of the customer, or 0 if the order was a guest checkout. May be worth using a foreign key relationship in a later iteration.
* order_total - Available for sorting via the WooCommerce > Orders screen in wp-admin

The `WC_Custom_Order_Table_Install::$table_version property` has also been incremented.

Fixes #13.