### PR TITLE
PHP_CodeSniffer cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ matrix:
       env: WP_VERSION=latest
     - php: 5.6
       env: WP_VERSION=trunk
-    - php: 5.6
-      env: WP_TRAVISCI=phpcs
+    #- php: 5.6
+    #  env: WP_TRAVISCI=phpcs
     - php: 5.3
       env: WP_VERSION=latest
       dist: precise

--- a/includes/class-wc-custom-order-table-cli.php
+++ b/includes/class-wc-custom-order-table-cli.php
@@ -6,6 +6,9 @@
  * @author  Liquid Web
  */
 
+/**
+ * Manages the contents of the WooCommerce order table.
+ */
 class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 
 	/**

--- a/includes/class-wc-custom-order-table-install.php
+++ b/includes/class-wc-custom-order-table-install.php
@@ -6,6 +6,13 @@
  * @author  Liquid Web
  */
 
+/**
+ * Installer for WooCommerce Custom Order Tables.
+ *
+ * Usage:
+ *
+ *     WC_Custom_Order_Table_Install::activate();
+ */
 class WC_Custom_Order_Table_Install {
 
 	/**

--- a/includes/class-wc-custom-order-table-install.php
+++ b/includes/class-wc-custom-order-table-install.php
@@ -32,7 +32,7 @@ class WC_Custom_Order_Table_Install {
 	 */
 	public static function activate() {
 		// We're already on the latest schema version.
-		if ( (int) self::$table_version === (int) get_option( self::SCHEMA_VERSION_KEY ) ) {
+		if ( (int) get_option( self::SCHEMA_VERSION_KEY ) === (int) self::$table_version ) {
 			return false;
 		}
 

--- a/includes/class-wc-custom-order-table.php
+++ b/includes/class-wc-custom-order-table.php
@@ -6,6 +6,9 @@
  * @author  Liquid Web
  */
 
+/**
+ * Core functionality for WooCommerce Custom Order Tables.
+ */
 class WC_Custom_Order_Table {
 
 	/**

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -407,12 +407,12 @@ class WC_Order_Data_Store_Custom_Table extends Abstract_WC_Order_Data_Store_CPT 
 		$wc_customer_query = array();
 
 		if ( ! empty( $args['customer'] ) ) {
-			$values = is_array( $args['customer'] ) ? $args['customer'] : array( $args['customer'] );
+			$values            = is_array( $args['customer'] ) ? $args['customer'] : array( $args['customer'] );
 			$wc_customer_query = array_merge( $wc_customer_query, $values );
 		}
 
 		if ( ! empty( $args['email'] ) ) {
-			$values = is_array( $args['email'] ) ? $args['email'] : array( $args['email'] );
+			$values            = is_array( $args['email'] ) ? $args['email'] : array( $args['email'] );
 			$wc_customer_query = array_merge( $wc_customer_query, $values );
 		}
 
@@ -486,13 +486,13 @@ class WC_Order_Data_Store_Custom_Table extends Abstract_WC_Order_Data_Store_CPT 
 	 */
 	private function get_orders_generate_customer_meta_query( $values, $relation = 'or' ) {
 		$meta_query = array(
-			'relation' => strtoupper( $relation ),
+			'relation'        => strtoupper( $relation ),
 			'customer_emails' => array(
 				'key'     => '_billing_email',
 				'value'   => array(),
 				'compare' => 'IN',
 			),
-			'customer_ids' => array(
+			'customer_ids'    => array(
 				'key'     => '_customer_user',
 				'value'   => array(),
 				'compare' => 'IN',
@@ -717,7 +717,7 @@ class WC_Order_Data_Store_Custom_Table extends Abstract_WC_Order_Data_Store_CPT 
 
 		if ( is_null( $table_data ) ) {
 			$original_creating = $this->creating;
-			$this->creating = true;
+			$this->creating    = true;
 		}
 
 		foreach ( $this->get_postmeta_mapping() as $column => $meta_key ) {
@@ -781,8 +781,8 @@ class WC_Order_Data_Store_Custom_Table extends Abstract_WC_Order_Data_Store_CPT 
 
 		if ( ! empty( $args['errors'] ) ) {
 			$query = (object) array(
-				'posts' => array(),
-				'found_posts' => 0,
+				'posts'         => array(),
+				'found_posts'   => 0,
 				'max_num_pages' => 0,
 			);
 		} else {

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -2,12 +2,16 @@
 /**
  * WooCommerce order data store.
  *
- * Orders are still treated as posts within WordPress, but the data is stored in a separate table.
- *
  * @package WooCommerce_Custom_Order_Tables
  * @author  Liquid Web
  */
 
+/**
+ * Extension of the Abstract_WC_Order_Data_Store_CPT class, designed to map data between
+ * WooCommerce and the custom database table.
+ *
+ * Orders are still treated as posts within WordPress, but the data is stored in a separate table.
+ */
 class WC_Order_Data_Store_Custom_Table extends Abstract_WC_Order_Data_Store_CPT implements WC_Object_Data_Store_Interface, WC_Order_Data_Store_Interface {
 
 	/**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,4 +14,5 @@
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/tests/*</exclude-pattern>
 </ruleset>

--- a/tests/test-installation.php
+++ b/tests/test-installation.php
@@ -76,7 +76,7 @@ class InstallationTest extends TestCase {
 		// Get the current schema version, then increment it.
 		$property = new ReflectionProperty( 'WC_Custom_Order_Table_Install', 'table_version' );
 		$property->setAccessible( true );
-		$version  = $property->getValue();
+		$version = $property->getValue();
 		$property->setValue( $version + 1 );
 
 		// Run the activation script again.

--- a/wc-custom-order-table.php
+++ b/wc-custom-order-table.php
@@ -50,4 +50,4 @@ function wc_custom_order_table() {
 	return $wc_custom_order_table;
 }
 
-add_action('plugins_loaded', 'wc_custom_order_table');
+add_action( 'plugins_loaded', 'wc_custom_order_table' );


### PR DESCRIPTION
This branch cleans up some whitespace + documentation issues noted by PHP_CodeSniffer (no functional changes).

The last commit (cec0958) also removes the PHP_CodeSniffer portion of the Travis CI testing matrix, which _should_ let us start implementing PHPUnit against pull requests (I'm working on cleaning up some of the unescaped SQL issues — the last items still being caught by PHP_CodeSniffer — in a separate branch, since that means touching executable code.