### PR TITLE
Adjust plugin bootstrapping

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,3 +30,61 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
 require __DIR__ . '/testcase.php';
+
+/*
+ * Automatically activate WooCommerce in the test environment.
+ *
+ * If WooCommerce cannot be activated, an error message will be thrown and the test execution
+ * halted, with a non-zero exit code.
+ */
+$activated = activate_plugin( 'woocommerce/woocommerce.php' );
+
+// If the issue is that the plugin isn't installed, attempt to install it.
+if ( is_wp_error( $activated ) && 'plugin_not_found' === $activated->get_error_code() ) {
+	include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+	echo PHP_EOL . "WooCommerce is not currently installed in the test environment, attempting to install...";
+
+	// Retrieve information about WooCommerce.
+	$plugin_data = wp_remote_get( 'https://api.wordpress.org/plugins/info/1.0/woocommerce.json' );
+
+	if ( ! is_wp_error( $plugin_data ) ) {
+		$plugin_data = json_decode( wp_remote_retrieve_body( $plugin_data ) );
+		$plugin_url  = $plugin_data->download_link;
+	} else {
+		$plugin_url = false;
+	}
+
+	// Download the plugin from the WordPress.org repository.
+	$upgrader  = new Plugin_Upgrader( new Automatic_Upgrader_Skin() );
+	$installed = $upgrader->install( $plugin_url );
+
+	if ( true === $installed ) {
+		echo "\033[0;32mOK\033[0;m" . PHP_EOL . PHP_EOL;
+	} else {
+		echo "\033[0;31mFAIL\033[0;m" . PHP_EOL;
+
+		if ( is_wp_error( $installed ) ) {
+			printf( 'Unable to install WooCommerce: %s.', $installed->get_error_message() );
+		}
+
+		printf(
+			'Please download and install WooCommerce into %s' . PHP_EOL,
+			trailingslashit(dirname( dirname( $_tests_dir ) ) )
+		);
+
+		exit( 1 );
+	}
+
+	// Try once again to activate.
+	$activated = activate_plugin( 'woocommerce/woocommerce.php' );
+}
+
+// Nothing more we can do, unfortunately.
+if ( is_wp_error( $activated ) ) {
+	echo PHP_EOL . 'WooCommerce could not automatically be activated in the test environment:';
+	echo PHP_EOL . $activated->get_error_message();
+	echo PHP_EOL . PHP_EOL . "\033[0;31mUnable to proceed with tests, aborting.\033[0m";
+	echo PHP_EOL;
+	exit( 1 );
+}

--- a/tests/test-bootstrap.php
+++ b/tests/test-bootstrap.php
@@ -6,7 +6,7 @@
  * @author  Liquid Web
  */
 
-class BootstrapTest extends WP_UnitTestCase {
+class BootstrapTest extends TestCase {
 
 	/**
 	 * Tear down the plugin after each test run.

--- a/tests/test-bootstrap.php
+++ b/tests/test-bootstrap.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Tests for the plugin bootstrapping.
+ *
+ * @package Woocommerce_Order_Tables
+ * @author  Liquid Web
+ */
+
+class BootstrapTest extends WP_UnitTestCase {
+
+	/**
+	 * Tear down the plugin after each test run.
+	 *
+	 * @before
+	 */
+	public function tear_down_plugin() {
+		global $wc_custom_order_table;
+
+		// Destroy the global $wc_custom_order_table instance.
+		unset( $wc_custom_order_table );
+	}
+
+	public function test_plugin_only_loads_after_woocommerce() {
+		global $wc_custom_order_table;
+
+		$this->assertNull(
+			$wc_custom_order_table,
+			'Before bootstrapping, $wc_custom_order_table should be empty.'
+		);
+
+		do_action( 'woocommerce_init' );
+
+		$this->assertInstanceOf(
+			'WC_Custom_Order_Table',
+			$wc_custom_order_table,
+			'The plugin should not be bootstrapped until woocommerce_init.'
+		);
+	}
+}

--- a/tests/test-sample.php
+++ b/tests/test-sample.php
@@ -1,14 +1,12 @@
 <?php
 /**
- * Class SampleTest
+ * Sample test case for WooCommerce Custom Order Tables.
  *
  * @package Woocommerce_Order_Tables
+ * @author  Liquid Web
  */
 
-/**
- * Sample test case.
- */
-class SampleTest extends WP_UnitTestCase {
+class SampleTest extends TestCase {
 
 	/**
 	 * A single example test.

--- a/wc-custom-order-table.php
+++ b/wc-custom-order-table.php
@@ -50,4 +50,4 @@ function wc_custom_order_table() {
 	return $wc_custom_order_table;
 }
 
-add_action('plugins_loaded', 'wc_custom_order_table');
+add_action( 'woocommerce_init', 'wc_custom_order_table' );


### PR DESCRIPTION
The main goal of this PR is to ensure that the plugin doesn't bootstrap itself (via `wc_custom_order_table()`) until the `woocommerce_init` action (not `plugins_loaded`, as is happening currently).

Once `woocommerce_init` is responsible for bootstrapping the plugin, we can move away from the bundled, PHP 5.2-compatible autoloader much easier.

## Verifying WooCommerce is installed

As our plugin will now require WooCommerce be present, we need to verify that WooCommerce is installed + active as part of the test suite. The resulting code in `tests/bootstrap.php` takes care of this, even automatically installing WooCommerce into the test environment if it doesn't already exist.

With this branch, the _first_ PHPUnit run will look something like this:

```
$ phpunit
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.

WooCommerce is not currently installed in the test environment, attempting to install...OK

PHPUnit 5.7.26 by Sebastian Bergmann and contributors.

.............                                                     13 / 13 (100%)

Time: 23.96 seconds, Memory: 36.00MB

OK (13 tests, 19 assertions)
```

Once WooCommerce has been installed in the test environment once, it'll simply activate what already exists:

```
$ phpunit
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 5.7.26 by Sebastian Bergmann and contributors.

.............                                                     13 / 13 (100%)

Time: 2.92 seconds, Memory: 34.00MB

OK (13 tests, 19 assertions)
```