### PR TITLE
Make adjustments to the Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ dist: trusty
 language: php
 
 notifications:
-  email:
-    on_success: never
-    on_failure: change
+  email: false
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,14 @@ cache:
 
 matrix:
   include:
+    - php: 7.2
+      env: WP_VERSION=trunk
     - php: 7.1
       env: WP_VERSION=latest
     - php: 7.0
       env: WP_VERSION=latest
     - php: 5.6
       env: WP_VERSION=latest
-    - php: 5.6
-      env: WP_VERSION=trunk
     #- php: 5.6
     #  env: WP_TRAVISCI=phpcs
     - php: 5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ notifications:
     on_success: never
     on_failure: change
 
-branches:
-  only:
-    - master
-
 cache:
   directories:
     - $HOME/.composer/cache

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # WooCommerce Order Tables
+
+[![Build Status](https://travis-ci.org/liquidweb/woocommerce-order-tables.svg?branch=fix%2Ftravis-config)](https://travis-ci.org/liquidweb/woocommerce-order-tables)
+
 Managed WooCommerce plugin for Liquid Web.
 
 ## Background & Purpose
 WooCommerce even with CRUD classes in core, still uses a custom post type for orders. By moving orders to use a custom table in the site database, will improve store orders performance.
 
 ### Here's how
-WooCommerce saves more than 40 custom fields per order— including those from plugins— inside the wp_postmeta table. If your store gets ~40 per day, that's 1600 rows (40 * 40) added to the postmeta table in a day. 
+WooCommerce saves more than 40 custom fields per order— including those from plugins— inside the wp_postmeta table. If your store gets ~40 per day, that's 1600 rows (40 * 40) added to the postmeta table in a day.
 
 In one month that number can be 48,000 new rows (1600 * 30) added to your postmeta table. The more rows in a table the longer it will take for a query to execute. WooCommerce Order Tables creates a new table for WooCommerce orders which would cut that number tremendously by making each custom field into a column so that 1 order = 1 row.
 


### PR DESCRIPTION
This PR updates the test matrix for Travis CI in the following ways:

* Favor more modern versions of PHP for both speed and forwards-compatibility
* Never send email notifications
* Don't restrict Travis to running against `master`, as we want to use it for PRs, `develop`, and more.

Since we have a working build, I've also added the build status to the README file.