### PR TITLE
Tests for the order data store

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 
-[{package.json,*.yml}]
+[{*.json,*.yml}]
 indent_style = space
 indent_size = 2
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/tests/coverage
 /vendor
 composer.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,3 +47,13 @@ Once master has been updated, the release should be tagged, then `master` should
 WooCommerce Custom Order Tables uses [the WordPress core testing suite](https://make.wordpress.org/core/handbook/testing/automated-testing/writing-phpunit-tests/) to provide automated tests for its functionality.
 
 When submitting pull requests, please include relevant tests for your new features and bugfixes. This helps prevent regressions in future iterations of the plugin, and helps instill confidence in store owners using this to enhance their WooCommerce stores.
+
+#### Test coverage
+
+To generate a code coverage report (test coverage percentage as well as areas of untested or under-tested code that could pose risk), you run the following:
+
+```sh
+$ composer test-coverage
+```
+
+The report will be saved to `tests/coverage/`. Please note that XDebug must be enabled in order to generate code coverage reports!

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
     ],
     "post-autoload-dump": [
       "xrstf\\Composer52\\Generator::onPostInstallCmd"
+    ],
+    "test-coverage": [
+      "phpunit --coverage-html=tests/coverage"
     ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,15 @@
   "type": "wordpress-plugin",
   "license": "GPL-2.0",
   "require": {
+    "php": ">=5.2",
     "composer/installers": "^1.4",
     "xrstf/composer-php52": "^1.0"
   },
   "autoload": {
     "classmap": ["includes"]
+  },
+  "autoload-dev": {
+    "classmap": ["tests/test-tools"]
   },
   "scripts": {
     "post-install-cmd": [

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -532,15 +532,16 @@ class WC_Order_Data_Store_Custom_Table extends Abstract_WC_Order_Data_Store_CPT 
 	public function get_unpaid_orders( $date ) {
 		global $wpdb;
 
-		$unpaid_orders = $wpdb->get_col( $wpdb->prepare( "
-			SELECT posts.ID
-			FROM {$wpdb->posts} AS posts
-			WHERE   posts.post_type   IN ('" . implode( "','", wc_get_order_types() ) . "')
-			AND     posts.post_status = 'wc-pending'
-			AND     posts.post_modified < %s
-		", date( 'Y-m-d H:i:s', absint( $date ) ) ) );
+		$order_types = wc_get_order_types();
 
-		return $unpaid_orders;
+		return $wpdb->get_col( $wpdb->prepare(
+			"SELECT ID
+				FROM $wpdb->posts
+				WHERE post_type IN (" . implode( ',', array_fill( 0, count( $order_types ), '%s' ) ) . ")
+				AND post_status = 'wc-pending'
+				AND post_modified < %s",
+			array_merge( $order_types, array( date( 'Y-m-d H:i:s', (int) $date ) ) )
+		) );
 	}
 
 	/**

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -572,7 +572,7 @@ class WC_Order_Data_Store_Custom_Table extends Abstract_WC_Order_Data_Store_CPT 
 		) ) );
 
 		$postmeta_search = ! empty( $meta_search_fields ) ? $wpdb->get_col(
-			$wpdb->prepare( "SELECT DISTINCT p1.post_id FROM {$wpdb->postmeta} p1 WHERE p1.meta_key IN ('" . implode( "','", array_map( 'esc_sql', $search_fields ) ) . "') AND p1.meta_value LIKE '%%%s%%';", wc_clean( $term ) )
+			$wpdb->prepare( "SELECT DISTINCT p1.post_id FROM {$wpdb->postmeta} p1 WHERE p1.meta_key IN ('" . implode( "','", array_map( 'esc_sql', $meta_search_fields ) ) . "') AND p1.meta_value LIKE '%%%s%%';", wc_clean( $term ) )
 		) : array();
 
 		return array_unique( array_merge(

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -582,9 +582,9 @@ class WC_Order_Data_Store_Custom_Table extends Abstract_WC_Order_Data_Store_CPT 
 				$wpdb->prepare( "
 						SELECT order_id
 						FROM {$wpdb->prefix}woocommerce_order_items as order_items
-						WHERE order_item_name LIKE '%%%s%%'
+						WHERE order_item_name LIKE %s
 						",
-					$term
+					'%' . $wpdb->esc_like( $term ) . '%'
 				)
 			)
 		) );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,4 +13,10 @@
 			<exclude>tests/test-sample.php</exclude>
 		</testsuite>
 	</testsuites>
+	<filter>
+		<whitelist>
+			<directory suffix=".php">includes</directory>
+			<file>wc-custom-order-table.php</file>
+		</whitelist>
+	</filter>
 </phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,6 +29,7 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
+require __DIR__ . '/../vendor/autoload_52.php';
 require __DIR__ . '/testcase.php';
 
 /*

--- a/tests/test-data-store.php
+++ b/tests/test-data-store.php
@@ -41,13 +41,14 @@ class DataStoreTest extends TestCase {
 	}
 
 	public function test_get_order_count() {
-		$orders = $this->factory()->order->create_many( 5, array(
+		$instance = new WC_Order_Data_Store_Custom_Table();
+		$orders   = $this->factory()->order->create_many( 5, array(
 			'post_status' => 'wc-pending',
 		) );
 
 		$this->assertEquals(
 			count( $orders ),
-			( new WC_Order_Data_Store_Custom_Table() )->get_order_count( 'wc-pending' )
+			$instance->get_order_count( 'wc-pending' )
 		);
 	}
 
@@ -64,11 +65,11 @@ class DataStoreTest extends TestCase {
 	}
 
 	public function test_get_unpaid_orders() {
-		$order   = $this->factory()->order->create( array(
+		$instance = new WC_Order_Data_Store_Custom_Table();
+		$order    = $this->factory()->order->create( array(
 			'post_status' => 'wc-pending',
 		) );
-		$pending = ( new WC_Order_Data_Store_Custom_Table() )
-			->get_unpaid_orders( time() + DAY_IN_SECONDS );
+		$pending  = $instance->get_unpaid_orders( time() + DAY_IN_SECONDS );
 
 		$this->assertCount( 1, $pending, 'There should be only one unpaid order.' );
 		$this->assertEquals(
@@ -79,11 +80,11 @@ class DataStoreTest extends TestCase {
 	}
 
 	public function test_get_unpaid_orders_uses_date_filtering() {
-		$order   = $this->factory()->order->create( array(
+		$instance = new WC_Order_Data_Store_Custom_Table();
+		$order    = $this->factory()->order->create( array(
 			'post_status' => 'wc-pending',
 		) );
-		$pending = ( new WC_Order_Data_Store_Custom_Table() )
-			->get_unpaid_orders( time() - HOUR_IN_SECONDS );
+		$pending  = $instance->get_unpaid_orders( time() - HOUR_IN_SECONDS );
 
 		$this->assertEmpty( $pending, 'No unpaid orders should match the time window.' );
 	}
@@ -97,8 +98,9 @@ class DataStoreTest extends TestCase {
 	}
 
 	public function test_search_orders_can_check_post_meta() {
-		$order = $this->factory()->order->create();
-		$term  = uniqid( 'search term ' );
+		$instance = new WC_Order_Data_Store_Custom_Table();
+		$order    = $this->factory()->order->create();
+		$term     = uniqid( 'search term ' );
 
 		add_post_meta( $order, 'some_custom_meta_key', $term );
 
@@ -108,7 +110,7 @@ class DataStoreTest extends TestCase {
 
 		$this->assertEquals(
 			array( $order ),
-			( new WC_Order_Data_Store_Custom_Table() )->search_orders( $term ),
+			$instance->search_orders( $term ),
 			'If post meta keys are specified, they should also be searched.'
 		);
 	}
@@ -117,41 +119,44 @@ class DataStoreTest extends TestCase {
 	 * Same as test_search_orders_can_check_post_meta(), but the filter is never added.
 	 */
 	public function test_search_orders_only_checks_post_meta_if_specified() {
-		$order = $this->factory()->order->create();
-		$term  = uniqid( 'search term ' );
+		$instance = new WC_Order_Data_Store_Custom_Table();
+		$order    = $this->factory()->order->create();
+		$term     = uniqid( 'search term ' );
 
 		add_post_meta( $order, 'some_custom_meta_key', $term );
 
 		$this->assertEmpty(
-			( new WC_Order_Data_Store_Custom_Table() )->search_orders( $term ),
+			$instance->search_orders( $term ),
 			'Only search post meta if keys are provided.'
 		);
 	}
 
 	public function test_search_orders_checks_table_for_product_item_matches() {
-		$product = $this->factory()->product->create_and_get();
-		$order = $this->factory()->order->create_and_get();
+		$instance = new WC_Order_Data_Store_Custom_Table();
+		$product  = $this->factory()->product->create_and_get();
+		$order    = $this->factory()->order->create_and_get();
 		$order->add_product( $product );
 		$order->save();
 
 		$this->assertEquals(
 			array( $order->get_id() ),
-			( new WC_Order_Data_Store_Custom_Table() )->search_orders( $product->get_name() ),
+			$instance->search_orders( $product->get_name() ),
 			'Order searches should extend to the names of product items.'
 		);
 	}
 
 	public function test_search_orders_checks_table_for_product_item_matches_with_like_comparison() {
-		$product = $this->factory()->product->create_and_get( array(
+		$instance = new WC_Order_Data_Store_Custom_Table();
+		$product  = $this->factory()->product->create_and_get( array(
 			'post_title' => 'foo bar baz',
 		) );
-		$order = $this->factory()->order->create_and_get();
+		$order    = $this->factory()->order->create_and_get();
 		$order->add_product( $product );
 		$order->save();
 
 		$this->assertEquals(
 			array( $order->get_id() ),
-			( new WC_Order_Data_Store_Custom_Table() )->search_orders( 'bar' ),
+			$instance->search_orders( 'bar' ),
 			'Product items should be searched using a LIKE comparison and wildcards.'
 		);
 	}
@@ -160,13 +165,14 @@ class DataStoreTest extends TestCase {
 	 * @dataProvider order_type_provider()
 	 */
 	public function test_get_order_type( $order_type ) {
-		$order = $this->factory()->order->create( array(
+		$instance = new WC_Order_Data_Store_Custom_Table();
+		$order    = $this->factory()->order->create( array(
 			'post_type' => $order_type,
 		) );
 
 		$this->assertEquals(
 			$order_type,
-			( new WC_Order_Data_Store_Custom_Table() )->get_order_type( $order )
+			$instance->get_order_type( $order )
 		);
 	}
 

--- a/tests/test-data-store.php
+++ b/tests/test-data-store.php
@@ -9,12 +9,35 @@
 class DataStoreTest extends TestCase {
 
 	/**
+	 * Fire the necessary actions to bootstrap WordPress.
+	 *
+	 * @before
+	 */
+	public function init() {
+		do_action( 'init' );
+	}
+
+	/**
 	 * Remove any closures that have been assigned to filters.
 	 *
 	 * @after
 	 */
 	public function remove_filter_callbacks() {
 		remove_all_filters( 'woocommerce_shop_order_search_fields' );
+	}
+
+	public function test_create() {
+		$instance  = new WC_Order_Data_Store_Custom_Table();
+		$order     = $this->factory()->order->create_and_get();
+		$order_key = 'my_custom_order_key';
+
+		add_filter( 'woocommerce_generate_order_key', function () use ( $order_key ) {
+			return $order_key;
+		} );
+
+		$instance->create( $order );
+
+		$this->assertEquals( 'wc_' . $order_key, $order->get_order_key() );
 	}
 
 	public function test_get_order_count() {
@@ -107,7 +130,7 @@ class DataStoreTest extends TestCase {
 	 * @dataProvider order_type_provider()
 	 */
 	public function test_get_order_type( $order_type ) {
-		$order = $this->factory()->order->create_and_get( array(
+		$order = $this->factory()->order->create( array(
 			'post_type' => $order_type,
 		) );
 

--- a/tests/test-data-store.php
+++ b/tests/test-data-store.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Tests for the WC_Order_Data_Store_Custom_Table class.
+ *
+ * @package Woocommerce_Order_Tables
+ * @author  Liquid Web
+ */
+
+class DataStoreTest extends TestCase {
+
+	public function test_get_order_count() {
+		$orders = $this->factory()->order->create_many( 5, array(
+			'post_status' => 'wc-pending',
+		) );
+
+		$this->assertEquals(
+			count( $orders ),
+			( new WC_Order_Data_Store_Custom_Table() )->get_order_count( 'wc-pending' )
+		);
+	}
+
+	public function test_get_order_count_filters_by_status() {
+		$this->factory()->order->create( array(
+			'post_status' => 'not_a_pending_status',
+		) );
+
+		$this->assertEquals(
+			0,
+			( new WC_Order_Data_Store_Custom_Table() )->get_order_count( 'wc-pending' ),
+			'The get_order_count() method should only count records matching $status.'
+		);
+	}
+
+	public function test_get_unpaid_orders() {
+		$order   = $this->factory()->order->create( array(
+			'post_status' => 'wc-pending',
+		) );
+		$pending = ( new WC_Order_Data_Store_Custom_Table() )
+			->get_unpaid_orders( time() + DAY_IN_SECONDS );
+
+		$this->assertCount( 1, $pending, 'There should be only one unpaid order.' );
+		$this->assertEquals(
+			$order,
+			array_shift( $pending ),
+			'The ID of the one unpaid order should be that of $order.'
+		);
+	}
+
+	public function test_get_unpaid_orders_uses_date_filtering() {
+		$order   = $this->factory()->order->create( array(
+			'post_status' => 'wc-pending',
+		) );
+		$pending = ( new WC_Order_Data_Store_Custom_Table() )
+			->get_unpaid_orders( time() - HOUR_IN_SECONDS );
+
+		$this->assertEmpty( $pending, 'No unpaid orders should match the time window.' );
+	}
+}

--- a/tests/test-data-store.php
+++ b/tests/test-data-store.php
@@ -97,17 +97,18 @@ class DataStoreTest extends TestCase {
 	}
 
 	public function test_search_orders_can_check_post_meta() {
-		$product = $this->factory()->product->create();
+		$order = $this->factory()->order->create();
+		$term  = uniqid( 'search term ' );
 
-		add_post_meta( $product, 'some_custom_meta_key', 'search term' );
+		add_post_meta( $order, 'some_custom_meta_key', $term );
 
 		add_filter( 'woocommerce_shop_order_search_fields', function () {
 			return array( 'some_custom_meta_key' );
 		} );
 
 		$this->assertEquals(
-			array( $product ),
-			( new WC_Order_Data_Store_Custom_Table() )->search_orders( 'search' ),
+			array( $order ),
+			( new WC_Order_Data_Store_Custom_Table() )->search_orders( $term ),
 			'If post meta keys are specified, they should also be searched.'
 		);
 	}
@@ -116,12 +117,13 @@ class DataStoreTest extends TestCase {
 	 * Same as test_search_orders_can_check_post_meta(), but the filter is never added.
 	 */
 	public function test_search_orders_only_checks_post_meta_if_specified() {
-		$product = $this->factory()->product->create();
+		$order = $this->factory()->order->create();
+		$term  = uniqid( 'search term ' );
 
-		add_post_meta( $product, 'some_custom_meta_key', 'search term' );
+		add_post_meta( $order, 'some_custom_meta_key', $term );
 
 		$this->assertEmpty(
-			( new WC_Order_Data_Store_Custom_Table() )->search_orders( 'search' ),
+			( new WC_Order_Data_Store_Custom_Table() )->search_orders( $term ),
 			'Only search post meta if keys are provided.'
 		);
 	}

--- a/tests/test-data-store.php
+++ b/tests/test-data-store.php
@@ -141,6 +141,21 @@ class DataStoreTest extends TestCase {
 		);
 	}
 
+	public function test_search_orders_checks_table_for_product_item_matches_with_like_comparison() {
+		$product = $this->factory()->product->create_and_get( array(
+			'post_title' => 'foo bar baz',
+		) );
+		$order = $this->factory()->order->create_and_get();
+		$order->add_product( $product );
+		$order->save();
+
+		$this->assertEquals(
+			array( $order->get_id() ),
+			( new WC_Order_Data_Store_Custom_Table() )->search_orders( 'bar' ),
+			'Product items should be searched using a LIKE comparison and wildcards.'
+		);
+	}
+
 	/**
 	 * @dataProvider order_type_provider()
 	 */

--- a/tests/test-data-store.php
+++ b/tests/test-data-store.php
@@ -128,6 +128,19 @@ class DataStoreTest extends TestCase {
 		);
 	}
 
+	public function test_search_orders_checks_table_for_product_item_matches() {
+		$product = $this->factory()->product->create_and_get();
+		$order = $this->factory()->order->create_and_get();
+		$order->add_product( $product );
+		$order->save();
+
+		$this->assertEquals(
+			array( $order->get_id() ),
+			( new WC_Order_Data_Store_Custom_Table() )->search_orders( $product->get_name() ),
+			'Order searches should extend to the names of product items.'
+		);
+	}
+
 	/**
 	 * @dataProvider order_type_provider()
 	 */

--- a/tests/test-data-store.php
+++ b/tests/test-data-store.php
@@ -55,4 +55,31 @@ class DataStoreTest extends TestCase {
 
 		$this->assertEmpty( $pending, 'No unpaid orders should match the time window.' );
 	}
+
+	/**
+	 * @dataProvider order_type_provider()
+	 */
+	public function test_get_order_type( $order_type ) {
+		$order = $this->factory()->order->create_and_get( array(
+			'post_type' => $order_type,
+		) );
+
+		$this->assertEquals(
+			$order_type,
+			( new WC_Order_Data_Store_Custom_Table() )->get_order_type( $order )
+		);
+	}
+
+	/**
+	 * Provide a list of all available order types.
+	 */
+	public function order_type_provider() {
+		$types = array();
+
+		foreach ( wc_get_order_types() as $type ) {
+			$types[ $type ] = array( $type );
+		}
+
+		return $types;
+	}
 }

--- a/tests/test-data-store.php
+++ b/tests/test-data-store.php
@@ -53,13 +53,14 @@ class DataStoreTest extends TestCase {
 	}
 
 	public function test_get_order_count_filters_by_status() {
+		$instance = new WC_Order_Data_Store_Custom_Table();
 		$this->factory()->order->create( array(
 			'post_status' => 'not_a_pending_status',
 		) );
 
 		$this->assertEquals(
 			0,
-			( new WC_Order_Data_Store_Custom_Table() )->get_order_count( 'wc-pending' ),
+			$instance->get_order_count( 'wc-pending' ),
 			'The get_order_count() method should only count records matching $status.'
 		);
 	}
@@ -90,9 +91,11 @@ class DataStoreTest extends TestCase {
 	}
 
 	public function test_search_orders_can_search_by_order_id() {
+		$instance = new WC_Order_Data_Store_Custom_Table();
+
 		$this->assertEquals(
 			array( 123 ),
-			( new WC_Order_Data_Store_Custom_Table() )->search_orders( 123 ),
+			$instance->search_orders( 123 ),
 			'When given a numeric value, search_orders() should include that order ID.'
 		);
 	}

--- a/tests/test-tools/class-wp-unittest-factory-for-customers.php
+++ b/tests/test-tools/class-wp-unittest-factory-for-customers.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Unit test factory for customers.
+ *
+ * Note: The below @method notations are defined solely for the benefit of IDEs,
+ * as a way to indicate expected return values from the given factory methods.
+ *
+ * @method int create( $args = array(), $generation_definitions = null )
+ * @method WP_User create_and_get( $args = array(), $generation_definitions = null )
+ * @method int[] create_many( $count, $args = array(), $generation_definitions = null )
+ */
+class WP_UnitTest_Factory_For_Customer extends WP_UnitTest_Factory_For_User {
+
+	function __construct( $factory = null ) {
+		parent::__construct( $factory );
+		$this->default_generation_definitions = array(
+			'user_login' => new WP_UnitTest_Generator_Sequence( 'Customer %s' ),
+			'user_pass'  => 'password',
+			'user_email' => new WP_UnitTest_Generator_Sequence( 'customer_%s@example.org' ),
+		);
+	}
+
+	function get_object_by_id( $user_id ) {
+		return new WC_Customer( $user_id );
+	}
+}

--- a/tests/test-tools/class-wp-unittest-factory-for-order.php
+++ b/tests/test-tools/class-wp-unittest-factory-for-order.php
@@ -21,4 +21,8 @@ class WP_UnitTest_Factory_For_Order extends WP_UnitTest_Factory_For_Post {
 			'post_type'     => 'shop_order',
 		);
 	}
+
+	function get_object_by_id( $order_id ) {
+		return wc_get_order( $order_id );
+	}
 }

--- a/tests/test-tools/class-wp-unittest-factory-for-order.php
+++ b/tests/test-tools/class-wp-unittest-factory-for-order.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Unit test factory for orders.
+ *
+ * Note: The below @method notations are defined solely for the benefit of IDEs,
+ * as a way to indicate expected return values from the given factory methods.
+ *
+ * @method int create( $args = array(), $generation_definitions = null )
+ * @method WP_Post create_and_get( $args = array(), $generation_definitions = null )
+ * @method int[] create_many( $count, $args = array(), $generation_definitions = null )
+ */
+class WP_UnitTest_Factory_For_Order extends WP_UnitTest_Factory_For_Post {
+
+	function __construct( $factory = null ) {
+		parent::__construct( $factory );
+		$this->default_generation_definitions = array(
+			'post_status'   => 'wc-pending',
+			'post_title'    => new WP_UnitTest_Generator_Sequence( 'Order %s' ),
+			'post_password' => uniqid( 'wc_' ),
+			'post_type'     => 'shop_order',
+		);
+	}
+}

--- a/tests/test-tools/class-wp-unittest-factory-for-product.php
+++ b/tests/test-tools/class-wp-unittest-factory-for-product.php
@@ -19,7 +19,7 @@ class WP_UnitTest_Factory_For_Product extends WP_UnitTest_Factory_For_Post {
 			'post_title'   => new WP_UnitTest_Generator_Sequence( 'Product name %s' ),
 			'post_content' => new WP_UnitTest_Generator_Sequence( 'Product description %s' ),
 			'post_excerpt' => new WP_UnitTest_Generator_Sequence( 'Product short description %s' ),
-			'post_type'    => 'post',
+			'post_type'    => 'product',
 		);
 	}
 

--- a/tests/test-tools/class-wp-unittest-factory-for-product.php
+++ b/tests/test-tools/class-wp-unittest-factory-for-product.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Unit test factory for products.
+ *
+ * Note: The below @method notations are defined solely for the benefit of IDEs,
+ * as a way to indicate expected return values from the given factory methods.
+ *
+ * @method int create( $args = array(), $generation_definitions = null )
+ * @method WP_Post create_and_get( $args = array(), $generation_definitions = null )
+ * @method int[] create_many( $count, $args = array(), $generation_definitions = null )
+ */
+class WP_UnitTest_Factory_For_Product extends WP_UnitTest_Factory_For_Post {
+
+	function __construct( $factory = null ) {
+		parent::__construct( $factory );
+		$this->default_generation_definitions = array(
+			'post_status'  => 'publish',
+			'post_title'   => new WP_UnitTest_Generator_Sequence( 'Product name %s' ),
+			'post_content' => new WP_UnitTest_Generator_Sequence( 'Product description %s' ),
+			'post_excerpt' => new WP_UnitTest_Generator_Sequence( 'Product short description %s' ),
+			'post_type'    => 'post',
+		);
+	}
+}

--- a/tests/test-tools/class-wp-unittest-factory-for-product.php
+++ b/tests/test-tools/class-wp-unittest-factory-for-product.php
@@ -22,4 +22,8 @@ class WP_UnitTest_Factory_For_Product extends WP_UnitTest_Factory_For_Post {
 			'post_type'    => 'post',
 		);
 	}
+
+	function get_object_by_id( $product_id ) {
+		return wc_get_product( $product_id );
+	}
 }

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -20,6 +20,7 @@ class TestCase extends WP_UnitTestCase {
 			$instance = new WP_UnitTest_Factory();
 
 			// Add additional factories.
+			$instance->customer = new WP_UnitTest_Factory_For_Customer( $instance );
 			$instance->order = new WP_UnitTest_Factory_For_Order( $instance );
 			$instance->product = new WP_UnitTest_Factory_For_Product( $instance );
 

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -9,6 +9,28 @@
 class TestCase extends WP_UnitTestCase {
 
 	/**
+	 * Retrieve the core test suite's factory object, but add extra factories.
+	 *
+	 * @return WP_UnitTest_Factory
+	 */
+	protected static function factory() {
+		static $factory = null;
+
+		if ( ! $factory ) {
+			$instance = new WP_UnitTest_Factory();
+
+			// Add additional factories.
+			$instance->order = new WP_UnitTest_Factory_For_Order( $instance );
+			$instance->product = new WP_UnitTest_Factory_For_Product( $instance );
+
+			// Save the instance in the static $factory variable.
+			$factory = $instance;
+		}
+
+		return $factory;
+	}
+
+	/**
 	 * Determine if the custom orders table exists.
 	 *
 	 * @global $wpdb


### PR DESCRIPTION
This PR focuses on getting some tests around some of the functionality within `includes/class-wc-order-data-store-custom-table.php` — there's still a long way to go, but the focus is getting tests around anything that required refactoring for security (namely some poorly-prepared SQL statements).

This branch also introduces some additional WP core test suite factories: Customers, Orders, and Products. Now, much like we can generate posts within our tests via `$this->factory()->post->create()`, we can do the same for three key areas of WooCommerce.