### PR TITLE
Refactor CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,53 @@ This plugin uses a Composer autoloader. If you are working with code from the `m
 
 The packaged version of this plugin, which is available in [releases](https://github.com/liquidweb/WooCommerce-Order-Tables/releases), contains the autoloader. This means that end users should not need to worry about running the `composer install` command to get things working. Just grab the latest release and go, but be sure to backup your database first!
 
-## How to use
-To be able migrate orders that are stored in the post type `shop_order` on your store, you will need to run a couple of WP-CLI commands. This plugin includes two WP-CLI commands, one is for getting how many orders have not been migrated yet into the order table `wp wc-order-table count`. The other WP-CLI command is to migrate the orders to the `woocommerce_order` database table, that command is `wp wc-order-table migrate --batch=500 --page=1`. So the default batch number of the orders to process is 1000, so you can adjust the batch number as needed.
+## Migrating order data
+
+After installing and activating the plugin, you'll need to migrate orders from post meta into the newly-created orders table.
+
+The easiest way to accomplish this is via [WP-CLI](http://wp-cli.org/), and the plugin ships with three commands to help:
+
+### Counting the orders to be migrated
+
+If you'd like to see the number of orders that have yet to be moved into the order table, you can quickly retrieve this value with the `count` command:
+
+```
+$ wp wc-order-table count
+```
+
+### Migrate order data from post meta to the orders table
+
+The `migrate` command will flatten the most common post meta values for WooCommerce orders into a flat database table, optimized for performance.
+
+```
+$ wp wc-order-table migrate
+```
+
+Orders are queried in batches (determined via the `--batch-size` option) in order to reduce the memory footprint of the command (e.g. "only retrieve {$size} orders at a time). Some environments may require a lower value than the default of 1000.
+
+#### Options
+
+<dl>
+	<dt>batch-size</dt>
+	<dd>The number of orders to process in each batch. Default is 1000 orders.</dd>
+</dl>
+
+
+### Copying data from the orders table into post meta
+
+If you require the post meta fields to be present (or are removing the custom order table plugin), you may rollback the migration at any time with the `backfill` command.
+
+```
+$ wp wc-order-table backfill
+```
+
+This command does the opposite of `migrate`, looping through the orders table and saving each column into the corresponding post meta key. Be aware that this may dramatically increase the size of your post meta table!
+
+#### Options
+
+<dl>
+	<dt>batch-size</dt>
+	<dd>The number of orders to process in each batch. Default is 1000 orders.</dd>
+	<dt>batch</dt>
+	<dd>The batch number to start from when migrating data. Default is 1.</dd>
+</dl>

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
     "classmap": [
       "tests/test-tools",
       "vendor/woocommerce/woocommerce/tests/framework"
+    ],
+    "files": [
+      "tests/test-tools/utils.php"
     ]
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
   },
   "autoload-dev": {
     "classmap": [
+      "tests/test-tools",
       "vendor/woocommerce/woocommerce/tests/framework"
     ]
   },

--- a/includes/class-wc-custom-order-table-cli.php
+++ b/includes/class-wc-custom-order-table-cli.php
@@ -24,14 +24,15 @@ class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 		global $wpdb;
 
 		$order_table = wc_custom_order_table()->get_table_name();
+		$order_types = wc_get_order_types( 'reports' );
 		$order_count = $wpdb->get_var( $wpdb->prepare(
-			"SELECT COUNT(1)
+			"SELECT COUNT(*)
 			FROM {$wpdb->posts} p
 			LEFT JOIN {$order_table} o ON p.ID = o.order_id
-			WHERE p.post_type IN ('%s')
+			WHERE p.post_type IN (" . implode( ', ', array_fill( 0, count( $order_types ), '%s' ) ) . ')
 			AND o.order_id IS NULL
-			ORDER BY p.post_date DESC",
-			implode( ',', wc_get_order_types( 'reports' ) )
+			ORDER BY p.post_date DESC',
+			$order_types
 		) );
 
 		WP_CLI::log( sprintf( __( '%d orders to be migrated.', 'wc-custom-order-table' ), $order_count ) );

--- a/includes/class-wc-custom-order-table-cli.php
+++ b/includes/class-wc-custom-order-table-cli.php
@@ -30,12 +30,14 @@ class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 			FROM {$wpdb->posts} p
 			LEFT JOIN {$order_table} o ON p.ID = o.order_id
 			WHERE p.post_type IN (" . implode( ', ', array_fill( 0, count( $order_types ), '%s' ) ) . ')
-			AND o.order_id IS NULL
-			ORDER BY p.post_date DESC',
+			AND o.order_id IS NULL',
 			$order_types
 		) );
 
-		WP_CLI::log( sprintf( __( '%d orders to be migrated.', 'wc-custom-order-table' ), $order_count ) );
+		WP_CLI::log( sprintf(
+			_n( 'There is %d order to be migrated.', 'There are %d orders to be migrated.', $order_count, 'wc-custom-order-table' ),
+			$order_count
+		) );
 
 		return $order_count;
 	}

--- a/includes/class-wc-custom-order-table-cli.php
+++ b/includes/class-wc-custom-order-table-cli.php
@@ -51,64 +51,65 @@ class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 	 * default: 1000
 	 * ---
 	 *
-	 * [--page=<page>]
-	 * : The page to start from.
-	 * ---
-	 * default: 1
-	 * ---
-	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp wc-order-table migrate --batch=100 --page=1
+	 *     wp wc-order-table migrate --batch=100
 	 *
 	 * @global $wpdb
 	 *
 	 * @param array $args       Positional arguments passed to the command.
 	 * @param array $assoc_args Associative arguments (options) passed to the command.
 	 */
-	public function migrate( $args, $assoc_args ) {
+	public function migrate( $args = array(), $assoc_args = array() ) {
 		global $wpdb;
 
-		$orders_batch      = isset( $assoc_args['batch'] ) ? absint( $assoc_args['batch'] ) : 1000;
-		$orders_page       = isset( $assoc_args['page'] ) ? absint( $assoc_args['page'] ) : 1;
-		$order_table       = wc_custom_order_table()->get_table_name();
-		$order_count       = $this->count();
-		$total_pages       = ceil( $order_count / $orders_batch );
-		$progress          = \WP_CLI\Utils\make_progress_bar( 'Order Data Migration', $order_count );
-		$batches_processed = 0;
-		$orders_sql        = $wpdb->prepare(
-			"SELECT ID FROM {$wpdb->posts}
-			WHERE post_type IN ('%s')
-			ORDER BY post_date DESC",
-			implode( ',', wc_get_order_types( 'reports' ) )
+		$order_count = $this->count();
+
+		if ( ! $order_count ) {
+			return WP_CLI::warning( __( 'There are no orders to migrate, aborting.', 'wc-custom-order-table' ) );
+		}
+
+		$assoc_args  = wp_parse_args( $assoc_args, array(
+			'batch' => 1000,
+		) );
+		$order_table = wc_custom_order_table()->get_table_name();
+		$order_types = wc_get_order_types( 'reports' );
+		$data_store  = new WC_Order_Data_Store_Custom_Table();
+		$progress    = WP_CLI\Utils\make_progress_bar( 'Order Data Migration', $order_count );
+		$processed   = 0;
+		$order_query = $wpdb->prepare(
+			"SELECT p.ID FROM {$wpdb->posts} p LEFT JOIN {$order_table} o ON p.ID = o.order_id
+			WHERE p.post_type IN (" . implode( ', ', array_fill( 0, count( $order_types ), '%s' ) ) . ')
+			AND o.order_id IS NULL
+			ORDER BY p.post_date DESC
+			LIMIT %d',
+			array_merge( $order_types, array( $assoc_args['batch'] ) )
 		);
+		$order_data  = $wpdb->get_col( $order_query );
 
-		// Work through each batch to migrate their orders.
-		for ( $page = $orders_page; $page <= $total_pages; $page++ ) {
-			$offset = ( $page * $orders_batch ) - $orders_batch;
-			$orders = $wpdb->get_col( $wpdb->prepare(
-				$orders_sql . ' LIMIT %d OFFSET %d',
-				$orders_batch,
-				max( $offset, 0 )
-			) );
+		while ( ! empty( $order_data ) ) {
+			foreach ( $order_data as $order_id ) {
+				$order = wc_get_order( $order_id );
+				$data_store->populate_from_meta( $order );
 
-			foreach ( $orders as $order ) {
-				// Accessing the order via wc_get_order will automatically migrate the order to the custom table.
-				wc_get_order( $order );
-
+				$processed++;
 				$progress->tick();
 			}
 
-			$batches_processed++;
+			// Load up the next batch.
+			$order_data = array_filter( $wpdb->get_col( $order_query, $processed ) );
 		}
 
 		$progress->finish();
 
-		WP_CLI::log( sprintf(
-			/* Translators: %1$d is the number of total orders, %2$d is the number of batches. */
-			__( '%1$d orders processed in %2$d batches.', 'wc-custom-order-table' ),
-			$order_count,
-			$batches_processed
+		// Issue a warning if no orders were migrated.
+		if ( ! $processed ) {
+			return WP_CLI::warning( __( 'No orders were migrated.', 'wc-custom-order-table' ) );
+		}
+
+		WP_CLI::success( sprintf(
+			_n( '%d order was migrated.', '%d orders were migrated.', $processed, 'wc-custom-order-table' ),
+			$processed
 		) );
 	}
 

--- a/includes/class-wc-custom-order-table-cli.php
+++ b/includes/class-wc-custom-order-table-cli.php
@@ -178,7 +178,10 @@ class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 		while ( ! empty( $order_data ) ) {
 			foreach ( $order_data as $order_id ) {
 				$order = wc_get_order( $order_id );
-				$order->get_data_store()->backfill_postmeta( $order );
+
+				if ( $order ) {
+					$order->get_data_store()->backfill_postmeta( $order );
+				}
 
 				$processed++;
 				$progress->tick();

--- a/includes/class-wc-custom-order-table-cli.php
+++ b/includes/class-wc-custom-order-table-cli.php
@@ -99,7 +99,7 @@ class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 			}
 
 			// Load up the next batch.
-			$order_data = array_filter( $wpdb->get_col( $order_query, $processed ) );
+			$order_data = array_filter( $wpdb->get_col( $order_query ) );
 		}
 
 		$progress->finish();

--- a/includes/class-wc-custom-order-table-cli.php
+++ b/includes/class-wc-custom-order-table-cli.php
@@ -35,7 +35,8 @@ class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 		) ); // WPCS: Unprepared SQL ok, DB call ok.
 
 		WP_CLI::log( sprintf(
-			_n( 'There is %d order to be migrated.', 'There are %d orders to be migrated.', $order_count, 'wc-custom-order-table' ),
+			/* Translators: %1$d is the number of orders to be migrated. */
+			_n( 'There is %1$d order to be migrated.', 'There are %1$d orders to be migrated.', $order_count, 'wc-custom-order-table' ),
 			$order_count
 		) );
 
@@ -109,7 +110,8 @@ class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 		}
 
 		WP_CLI::success( sprintf(
-			_n( '%d order was migrated.', '%d orders were migrated.', $processed, 'wc-custom-order-table' ),
+			/* Translators: %1$d is the number of migrated orders. */
+			_n( '%1$d order was migrated.', '%1$d orders were migrated.', $processed, 'wc-custom-order-table' ),
 			$processed
 		) );
 	}
@@ -181,7 +183,8 @@ class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 		}
 
 		WP_CLI::success( sprintf(
-			_n( '%d order was migrated.', '%d orders were migrated.', $processed, 'wc-custom-order-table' ),
+			/* Translators: %1$d is the number of migrated orders. */
+			_n( '%1$d order was migrated.', '%1$d orders were migrated.', $processed, 'wc-custom-order-table' ),
 			$processed
 		) );
 	}

--- a/includes/class-wc-custom-order-table-cli.php
+++ b/includes/class-wc-custom-order-table-cli.php
@@ -32,7 +32,7 @@ class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 			WHERE p.post_type IN (" . implode( ', ', array_fill( 0, count( $order_types ), '%s' ) ) . ')
 			AND o.order_id IS NULL',
 			$order_types
-		) );
+		) ); // WPCS: Unprepared SQL ok, DB call ok.
 
 		WP_CLI::log( sprintf(
 			_n( 'There is %d order to be migrated.', 'There are %d orders to be migrated.', $order_count, 'wc-custom-order-table' ),
@@ -79,14 +79,14 @@ class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 		$progress    = WP_CLI\Utils\make_progress_bar( 'Order Data Migration', $order_count );
 		$processed   = 0;
 		$order_query = $wpdb->prepare(
-			"SELECT p.ID FROM {$wpdb->posts} p LEFT JOIN {$order_table} o ON p.ID = o.order_id
-			WHERE p.post_type IN (" . implode( ', ', array_fill( 0, count( $order_types ), '%s' ) ) . ')
+			"SELECT p.ID FROM {$wpdb->posts} p LEFT JOIN " . esc_sql( $order_table ) . ' o ON p.ID = o.order_id
+			WHERE p.post_type IN (' . implode( ', ', array_fill( 0, count( $order_types ), '%s' ) ) . ')
 			AND o.order_id IS NULL
 			ORDER BY p.post_date DESC
 			LIMIT %d',
 			array_merge( $order_types, array( $assoc_args['batch'] ) )
 		);
-		$order_data  = $wpdb->get_col( $order_query );
+		$order_data  = $wpdb->get_col( $order_query ); // WPCS: Unprepared SQL ok, DB call ok.
 
 		while ( ! empty( $order_data ) ) {
 			foreach ( $order_data as $order_id ) {
@@ -98,7 +98,7 @@ class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 			}
 
 			// Load up the next batch.
-			$order_data = array_filter( $wpdb->get_col( $order_query ) );
+			$order_data = array_filter( $wpdb->get_col( $order_query ) ); // WPCS: Unprepared SQL ok, DB call ok.
 		}
 
 		$progress->finish();
@@ -144,7 +144,7 @@ class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 		global $wpdb;
 
 		$order_table = wc_custom_order_table()->get_table_name();
-		$order_count = $wpdb->get_var( 'SELECT COUNT(order_id) FROM ' . esc_sql( $order_table ) );
+		$order_count = $wpdb->get_var( 'SELECT COUNT(order_id) FROM ' . esc_sql( $order_table ) ); // WPCS: DB call ok.
 
 		if ( ! $order_count ) {
 			return WP_CLI::warning( __( 'There are no orders to migrate, aborting.', 'wc-custom-order-table' ) );
@@ -158,7 +158,7 @@ class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 		$processed   = 0;
 		$starting    = ( $assoc_args['page'] - 1 ) * $assoc_args['batch'];
 		$order_query = 'SELECT order_id FROM ' . esc_sql( $order_table ) . ' LIMIT %d, %d';
-		$order_data  = $wpdb->get_col( $wpdb->prepare( $order_query, $starting, $assoc_args['batch'] ) );
+		$order_data  = $wpdb->get_col( $wpdb->prepare( $order_query, $starting, $assoc_args['batch'] ) ); // WPCS: Unprepared SQL ok, DB call ok.
 
 		while ( ! empty( $order_data ) ) {
 			foreach ( $order_data as $order_id ) {
@@ -170,7 +170,7 @@ class WC_Custom_Order_Table_CLI extends WP_CLI_Command {
 			}
 
 			// Load up the next batch.
-			$order_data = $wpdb->get_col( $wpdb->prepare( $order_query, $starting + $processed, $assoc_args['batch'] ) );
+			$order_data = $wpdb->get_col( $wpdb->prepare( $order_query, $starting + $processed, $assoc_args['batch'] ) ); // WPCS: Unprepared SQL ok, DB call ok.
 		}
 
 		$progress->finish();

--- a/includes/class-wc-custom-order-table.php
+++ b/includes/class-wc-custom-order-table.php
@@ -29,8 +29,8 @@ class WC_Custom_Order_Table {
 		$this->table_name = $wpdb->prefix . 'woocommerce_orders';
 
 		// Use the plugin's custom data stores for customers and orders.
-		add_filter( 'woocommerce_customer_data_store', array( $this, 'customer_data_store' ) );
-		add_filter( 'woocommerce_order_data_store', array( $this, 'order_data_store' ) );
+		add_filter( 'woocommerce_customer_data_store', __CLASS__ . '::customer_data_store' );
+		add_filter( 'woocommerce_order_data_store', __CLASS__ . '::order_data_store' );
 
 		// If we're in a WP-CLI context, load the WP-CLI command.
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
@@ -57,7 +57,7 @@ class WC_Custom_Order_Table {
 	 *
 	 * @return string The data store class name.
 	 */
-	public function customer_data_store() {
+	public static function customer_data_store() {
 		return 'WC_Customer_Data_Store_Custom_Table';
 	}
 
@@ -66,7 +66,7 @@ class WC_Custom_Order_Table {
 	 *
 	 * @return string The data store class name.
 	 */
-	public function order_data_store() {
+	public static function order_data_store() {
 		return 'WC_Order_Data_Store_Custom_Table';
 	}
 }

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -389,20 +389,13 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 	 * Populate custom table with data from postmeta, for migrations.
 	 *
 	 * @param WC_Order $order  The order object, passed by reference.
-	 * @param bool     $save   Optional. Whether or not the post meta should be updated. Default
-	 *                         is true.
 	 * @param bool     $delete Optional. Whether or not the post meta should be deleted. Default
 	 *                         is false.
 	 *
 	 * @return WC_Order the order object.
 	 */
-	public function populate_from_meta( &$order, $save = true, $delete = false ) {
+	public function populate_from_meta( &$order, $delete = false ) {
 		$table_data = $this->get_order_data_from_table( $order );
-		$original_creating = $this->creating;
-
-		if ( is_null( $table_data ) ) {
-			$this->creating = true;
-		}
 
 		foreach ( self::get_postmeta_mapping() as $column => $meta_key ) {
 			$meta = get_post_meta( $order->get_id(), $meta_key, true );
@@ -419,21 +412,18 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 
 					default:
 						$order->{"set_{$column}"}( $meta );
+						break;
 				}
 			}
 		}
 
-		if ( true === $save ) {
-			$this->update_post_meta( $order );
-		}
+		$this->update_post_meta( $order );
 
 		if ( true === $delete ) {
 			foreach ( self::get_postmeta_mapping() as $column => $meta_key ) {
 				delete_post_meta( $order->get_id(), $meta_key );
 			}
 		}
-
-		$this->creating = $original_creating;
 
 		return $order;
 	}

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -450,9 +450,13 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 			return;
 		}
 
+		if ( isset( $data['prices_include_tax'] ) ) {
+			$data['prices_include_tax'] = wc_bool_to_string( $data['prices_include_tax'] );
+		}
+
 		foreach ( self::get_postmeta_mapping() as $column => $meta_key ) {
-			if ( isset( $data->$column ) ) {
-				update_post_meta( $order->get_id(), $meta_key, $data->$column );
+			if ( isset( $data[ $column ] ) ) {
+				update_post_meta( $order->get_id(), $meta_key, $data[ $column ] );
 			}
 		}
 	}

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -403,7 +403,7 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 			if ( empty( $table_data->$column ) && ! empty( $meta ) ) {
 				switch ( $column ) {
 					case 'billing_index':
-					case 'shipping_index';
+					case 'shipping_index':
 						break;
 
 					case 'prices_include_tax':

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -428,7 +428,6 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 			return new WP_Error( 'woocommerce-custom-order-table-migration', $wpdb->last_error );
 		}
 
-
 		if ( true === $delete ) {
 			foreach ( self::get_postmeta_mapping() as $column => $meta_key ) {
 				delete_post_meta( $order->get_id(), $meta_key );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,6 +7,17 @@
 		<exclude name="Core.Commenting.CommentTags.AuthorTag" />
 	</rule>
 
+	<rule ref="WordPress.WP.I18n">
+		<!-- Set the expected text domain. -->
+		<properties>
+			<property name="text_domain" type="array" value="wc-custom-order-table" />
+		</properties>
+	</rule>
+
+	<rule ref="PHPCompatibility">
+		<exclude name="PHPCompatibility.PHP.NewKeywords.t_namespaceFound" />
+		<exclude-pattern>includes/class-wc-custom-order-table-cli.php</exclude-pattern>
+	</rule>
 
 	<!-- Check all PHP files in directory tree by default. -->
 	<arg name="extensions" value="php"/>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,5 +35,6 @@ function _manually_load_plugin() {
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 // Finally, Start up the WP testing environment.
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 require_once $_bootstrap;
 require_once __DIR__ . '/testcase.php';

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Tests for the WP-CLI commands.
+ *
+ * @package Woocommerce_Order_Tables
+ * @author  Liquid Web
+ */
+
+class CLITest extends TestCase {
+
+	/**
+	 * Holds a fresh instance of the WP-CLI command class.
+	 *
+	 * @var WC_Custom_Order_Table_CLI
+	 */
+	protected $cli;
+
+	/**
+	 * @before
+	 */
+	public function init() {
+		$this->cli = new WC_Custom_Order_Table_CLI();
+	}
+
+	public function test_count() {
+		$this->toggle_use_custom_table( false );
+		$this->generate_orders( 3 );
+		$this->toggle_use_custom_table( true );
+
+		$this->assertEquals( 3, $this->cli->count() );
+	}
+
+	public function test_migrate() {
+		$this->markTestIncomplete();
+
+		$this->toggle_use_custom_table( false );
+		$order_ids = $this->generate_orders( 5 );
+		$this->toggle_use_custom_table( true );
+
+		$this->assertEquals(
+			0,
+			$this->count_orders_in_table_with_ids( $order_ids ),
+			'Before migration, these orders should not exist in the orders table.'
+		);
+
+		// @todo The migration
+
+		$this->assertEquals(
+			5,
+			$this->count_orders_in_table_with_ids( $order_ids ),
+			'Expected to see 5 orders in the custom table.'
+		);
+	}
+
+	public function test_backfill() {
+		$this->markTestIncomplete();
+	}
+
+	/**
+	 * Generate a $number of orders and return the order IDs in an array.
+	 *
+	 * @param int $number The number of orders to generate.
+	 *
+	 * @return array An array of the generated order IDs.
+	 */
+	protected function generate_orders( $number = 5 ) {
+		$orders = array();
+
+		for ( $i = 0; $i < $number; $i++ ) {
+			$orders[] = WC_Helper_Order::create_order()->get_id();
+		}
+
+		return $orders;
+	}
+}

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -70,6 +70,22 @@ class CLITest extends TestCase {
 	}
 
 	public function test_backfill() {
-		$this->markTestIncomplete();
+		$order_ids = $this->generate_orders( 5 );
+		$index     = 0;
+
+		foreach ( $order_ids as $order_id ) {
+			$this->assertEmpty( get_post_meta( $order_id, '_billing_email', true ) );
+		}
+
+		$this->cli->backfill(array(), array( 'batch' => 2));
+
+		foreach ( $order_ids as $order_id ) {
+			$index++;
+
+			$this->assertNotEmpty(
+				get_post_meta( $order_id, '_billing_email', true ),
+				"The billing email for order #{$index} was not saved to post meta."
+			);
+		}
 	}
 }

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -50,6 +50,25 @@ class CLITest extends TestCase {
 		);
 	}
 
+	public function test_migrate_works_in_batches() {
+		global $wpdb;
+
+		$this->toggle_use_custom_table( false );
+		$order_ids = $this->generate_orders( 5 );
+		$this->toggle_use_custom_table( true );
+
+		$this->cli->migrate( array(), array(
+			'batch' => 2,
+		) );
+
+		$this->assertContains( 'LIMIT 2', $wpdb->last_query, 'The batch size should be used to limit query results.' );
+		$this->assertEquals(
+			5,
+			$this->count_orders_in_table_with_ids( $order_ids ),
+			'Expected to see 5 total orders in the custom table.'
+		);
+	}
+
 	public function test_backfill() {
 		$this->markTestIncomplete();
 	}

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -69,6 +69,28 @@ class CLITest extends TestCase {
 		);
 	}
 
+	/**
+	 * Trigger a database error in the same way as the test_populate_from_meta_handles_errors test.
+	 *
+	 * @see DataStoreTest::test_populate_from_meta_handles_errors()
+	 */
+	public function test_migrate_stops_on_database_error() {
+		$this->toggle_use_custom_table( false );
+		$order1 = WC_Helper_Order::create_order();
+		$order1->set_order_key( '' );
+		$order1->save();
+		$order2 = WC_Helper_Order::create_order();
+		$order2->set_order_key( '' );
+		$order2->save();
+		$this->toggle_use_custom_table( true );
+
+		$this->cli->migrate();
+
+		$error = array_pop( WP_CLI::$__logger );
+		$this->assertEquals( 'error', $error['level'], 'Expected to see a call to WP_CLI::error().' );
+
+	}
+
 	public function test_backfill() {
 		$order_ids = $this->generate_orders( 5 );
 		$index     = 0;

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -31,8 +31,6 @@ class CLITest extends TestCase {
 	}
 
 	public function test_migrate() {
-		$this->markTestIncomplete();
-
 		$this->toggle_use_custom_table( false );
 		$order_ids = $this->generate_orders( 5 );
 		$this->toggle_use_custom_table( true );
@@ -43,7 +41,7 @@ class CLITest extends TestCase {
 			'Before migration, these orders should not exist in the orders table.'
 		);
 
-		// @todo The migration
+		$this->cli->migrate();
 
 		$this->assertEquals(
 			5,
@@ -54,22 +52,5 @@ class CLITest extends TestCase {
 
 	public function test_backfill() {
 		$this->markTestIncomplete();
-	}
-
-	/**
-	 * Generate a $number of orders and return the order IDs in an array.
-	 *
-	 * @param int $number The number of orders to generate.
-	 *
-	 * @return array An array of the generated order IDs.
-	 */
-	protected function generate_orders( $number = 5 ) {
-		$orders = array();
-
-		for ( $i = 0; $i < $number; $i++ ) {
-			$orders[] = WC_Helper_Order::create_order()->get_id();
-		}
-
-		return $orders;
 	}
 }

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -112,4 +112,17 @@ class CLITest extends TestCase {
 			);
 		}
 	}
+
+	public function test_backfill_when_an_order_has_been_deleted() {
+		$order1 = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
+
+		// The order has been force deleted.
+		wp_delete_post( $order1->get_id(), true );
+
+		$this->cli->backfill();
+
+		$this->assertEmpty( get_post_meta( $order1->get_id(), '_billing_email', true ) );
+		$this->assertNotEmpty( get_post_meta( $order2->get_id(), '_billing_email', true ) );
+	}
 }

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -58,7 +58,7 @@ class CLITest extends TestCase {
 		$this->toggle_use_custom_table( true );
 
 		$this->cli->migrate( array(), array(
-			'batch' => 2,
+			'batch-size' => 2,
 		) );
 
 		$this->assertContains( 'LIMIT 2', $wpdb->last_query, 'The batch size should be used to limit query results.' );
@@ -77,7 +77,9 @@ class CLITest extends TestCase {
 			$this->assertEmpty( get_post_meta( $order_id, '_billing_email', true ) );
 		}
 
-		$this->cli->backfill(array(), array( 'batch' => 2));
+		$this->cli->backfill( array(), array(
+			'batch-size' => 2,
+		) );
 
 		foreach ( $order_ids as $order_id ) {
 			$index++;

--- a/tests/test-data-store.php
+++ b/tests/test-data-store.php
@@ -53,6 +53,23 @@ class DataStoreTest extends TestCase {
 		$this->assertNull( $this->get_order_row( $order_id ), 'When force deleting, the table row should be removed.' );
 	}
 
+	public function test_get_order_data_from_table() {
+		$order = WC_Helper_Order::create_order();
+		$data  = $order->get_data_store()->get_order_data_from_table( $order );
+
+		$this->assertEquals( $order->get_id(), $data['order_id'] );
+		$this->assertEquals( $order->get_billing_email(), $data['billing_email'] );
+		$this->assertEquals( $order->get_prices_include_tax(), $data['prices_include_tax'] );
+	}
+
+	public function test_get_order_data_from_table_when_order_is_still_in_post_meta() {
+		$this->toggle_use_custom_table( false );
+		$order = WC_Helper_Order::create_order();
+		$this->toggle_use_custom_table( true );
+
+		$this->assertEmpty( $order->get_data_store()->get_order_data_from_table( $order ) );
+	}
+
 	public function test_update_post_meta_for_new_order() {
 		$order = new WC_Order( wp_insert_post( array(
 			'post_type' => 'product',

--- a/tests/test-data-store.php
+++ b/tests/test-data-store.php
@@ -161,6 +161,27 @@ class DataStoreTest extends TestCase {
 		);
 	}
 
+	public function test_backfill_postmeta() {
+		$instance = new WC_Order_Data_Store_Custom_Table();
+		$order    = WC_Helper_Order::create_order();
+		$row      = $this->get_order_row( $order->get_id() );
+		$mapping  = WC_Order_Data_Store_Custom_Table::get_postmeta_mapping();
+
+		foreach ( $mapping as $column => $meta_key ) {
+			$this->assertEmpty( get_post_meta( $order->get_id(), $meta_key, true ) );
+		}
+
+		$instance->backfill_postmeta( $order );
+
+		foreach ( $mapping as $column => $meta_key ) {
+			$this->assertEquals(
+				$row[ $column ],
+				get_post_meta( $order->get_id(), $meta_key, true ),
+				"Value of the $meta_key meta key did not meet expectations."
+			);
+		}
+	}
+
 	/**
 	 * Shortcut for setting up reflection methods + properties for update_post_meta().
 	 *

--- a/tests/test-tools/class-mock-progress-bar.php
+++ b/tests/test-tools/class-mock-progress-bar.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Mock CLI progress bar for testing WP-CLI.
+ */
+
+class MockProgressBar {
+
+	public function __construct( $message, $count, $interval ) {
+
+	}
+
+	public function tick() {
+
+	}
+
+	public function finish() {
+
+	}
+}

--- a/tests/test-tools/class-wp-cli-command.php
+++ b/tests/test-tools/class-wp-cli-command.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Dummy test class for WP_CLI_Command.
+ */
+
+if ( ! class_exists( 'WP_CLI_Command' ) ) {
+	class WP_CLI_Command {
+
+	}
+}

--- a/tests/test-tools/class-wp-cli.php
+++ b/tests/test-tools/class-wp-cli.php
@@ -18,5 +18,19 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 				'message' => $message,
 			);
 		}
+
+		public static function success( $message ) {
+			self::$__logger[] = array(
+				'level'   => 'success',
+				'message' => $message,
+			);
+		}
+
+		public static function warning( $message ) {
+			self::$__logger[] = array(
+				'level'   => 'warning',
+				'message' => $message,
+			);
+		}
 	}
 }

--- a/tests/test-tools/class-wp-cli.php
+++ b/tests/test-tools/class-wp-cli.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Dummy test class for WP_CLI.
+ */
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	class WP_CLI {
+		public static $__commands = array();
+		public static $__logger   = array();
+
+		public static function add_command( $name, $callable, $args = array() ) {
+			self::$__commands[] = func_get_args();
+		}
+
+		public static function log( $message ) {
+			self::$__logger[] = array(
+				'level'   => 'info',
+				'message' => $message,
+			);
+		}
+	}
+}

--- a/tests/test-tools/class-wp-cli.php
+++ b/tests/test-tools/class-wp-cli.php
@@ -32,5 +32,12 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 				'message' => $message,
 			);
 		}
+
+		public static function error( $message ) {
+			self::$__logger[] = array(
+				'level'   => 'error',
+				'message' => $message,
+			);
+		}
 	}
 }

--- a/tests/test-tools/utils.php
+++ b/tests/test-tools/utils.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Dummy utility functions for WP-CLI.
+ */
+
+namespace WP_CLI\Utils;
+
+use MockProgressBar;
+
+if ( ! function_exists( __NAMESPACE__ . '\make_progress_bar' ) ) {
+	function make_progress_bar( $message, $count, $interval = 100 ) {
+		return new MockProgressBar( $message, $count, $interval );
+	}
+}

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -15,10 +15,49 @@ class TestCase extends WC_Unit_Test_Case {
 	 *
 	 * @global $wpdb
 	 */
-	function truncate_table() {
+	protected function truncate_table() {
 		global $wpdb;
 
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_orders" );
+	}
+
+	/**
+	 * Toggle whether or not the custom table should be used.
+	 *
+	 * @param bool $enabled Optional. Whether or not the custom table should be used. Default is true.
+	 */
+	protected function toggle_use_custom_table( $enabled = true ) {
+		$instance = wc_custom_order_table();
+
+		if ( $enabled ) {
+			add_filter( 'woocommerce_customer_data_store', array( $instance, 'customer_data_store' ) );
+			add_filter( 'woocommerce_order_data_store', array( $instance, 'order_data_store' ) );
+		} else {
+			remove_filter( 'woocommerce_customer_data_store', array( $instance, 'customer_data_store' ) );
+			remove_filter( 'woocommerce_order_data_store', array( $instance, 'order_data_store' ) );
+		}
+	}
+
+	/**
+	 * Given an array of IDs, see how many of those IDs exist in the table.
+	 *
+	 * @global $wpdb
+	 *
+	 * @param array $order_ids An array of order IDs to look for.
+	 *
+	 * @return int The number of matches found in the database.
+	 */
+	protected function count_orders_in_table_with_ids( $order_ids = array() ) {
+		global $wpdb;
+
+		if ( empty( $order_ids ) ) {
+			return 0;
+		}
+
+		return (int) $wpdb->get_var( $wpdb->prepare( "
+			SELECT COUNT(order_id) FROM {$wpdb->prefix}woocommerce_orders
+			WHERE order_id IN (" . implode( ', ', array_fill( 0, count( $order_ids ), '%d' ) ) . ')',
+		$order_ids ) );
 	}
 
 	/**

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -27,14 +27,12 @@ class TestCase extends WC_Unit_Test_Case {
 	 * @param bool $enabled Optional. Whether or not the custom table should be used. Default is true.
 	 */
 	protected function toggle_use_custom_table( $enabled = true ) {
-		$instance = wc_custom_order_table();
-
 		if ( $enabled ) {
-			add_filter( 'woocommerce_customer_data_store', array( $instance, 'customer_data_store' ) );
-			add_filter( 'woocommerce_order_data_store', array( $instance, 'order_data_store' ) );
+			add_filter( 'woocommerce_customer_data_store', 'WC_Custom_Order_Table::customer_data_store' );
+			add_filter( 'woocommerce_order_data_store', 'WC_Custom_Order_Table::order_data_store' );
 		} else {
-			remove_filter( 'woocommerce_customer_data_store', array( $instance, 'customer_data_store' ) );
-			remove_filter( 'woocommerce_order_data_store', array( $instance, 'order_data_store' ) );
+			remove_filter( 'woocommerce_customer_data_store', 'WC_Custom_Order_Table::customer_data_store' );
+			remove_filter( 'woocommerce_order_data_store', 'WC_Custom_Order_Table::order_data_store' );
 		}
 	}
 

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -39,6 +39,23 @@ class TestCase extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Generate a $number of orders and return the order IDs in an array.
+	 *
+	 * @param int $number The number of orders to generate.
+	 *
+	 * @return array An array of the generated order IDs.
+	 */
+	protected function generate_orders( $number = 5 ) {
+		$orders = array();
+
+		for ( $i = 0; $i < $number; $i++ ) {
+			$orders[] = WC_Helper_Order::create_order()->get_id();
+		}
+
+		return $orders;
+	}
+
+	/**
 	 * Given an array of IDs, see how many of those IDs exist in the table.
 	 *
 	 * @global $wpdb


### PR DESCRIPTION
This PR refactors the WP-CLI commands, adding tests and ensuring that data is reliably migrated back and forth between the custom orders and the post meta tables.

This PR also represents the last PHP_CodeSniffer violations for the project, so once merged all Travis tests should be passing (whoo!)

Fixes #27.