### PR TITLE
Remove the Composer-generated autoloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,5 @@ WooCommerce saves more than 40 custom fields per order— including those from p
 
 In one month that number can be 48,000 new rows (1600 * 30) added to your postmeta table. The more rows in a table the longer it will take for a query to execute. WooCommerce Order Tables creates a new table for WooCommerce orders which would cut that number tremendously by making each custom field into a column so that 1 order = 1 row.
 
-## Installation
-This plugin uses a Composer autoloader. If you are working with code from the `master` branch in a development environment, the autoloader needs to be generated in order for the plugin to work. After cloning this repository, run `composer install` in the root directory of the plugin.
-
-The packaged version of this plugin, which is available in [releases](https://github.com/liquidweb/WooCommerce-Order-Tables/releases), contains the autoloader. This means that end users should not need to worry about running the `composer install` command to get things working. Just grab the latest release and go, but be sure to backup your database first!
-
 ## How to use
 To be able migrate orders that are stored in the post type `shop_order` on your store, you will need to run a couple of WP-CLI commands. This plugin includes two WP-CLI commands, one is for getting how many orders have not been migrated yet into the order table `wp wc-order-table count`. The other WP-CLI command is to migrate the orders to the `woocommerce_order` database table, that command is `wp wc-order-table migrate --batch=500 --page=1`. So the default batch number of the orders to process is 1000, so you can adjust the batch number as needed.

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,7 @@
   "type": "wordpress-plugin",
   "license": "GPL-2.0",
   "require": {
-    "php": ">=5.2",
-    "composer/installers": "^1.4",
-    "xrstf/composer-php52": "^1.0"
+    "php": ">=5.2"
   },
   "require-dev": {
     "php": "^7.0",
@@ -27,15 +25,6 @@
     ]
   },
   "scripts": {
-    "post-install-cmd": [
-      "xrstf\\Composer52\\Generator::onPostInstallCmd"
-    ],
-    "post-update-cmd": [
-      "xrstf\\Composer52\\Generator::onPostInstallCmd"
-    ],
-    "post-autoload-dump": [
-      "xrstf\\Composer52\\Generator::onPostInstallCmd"
-    ],
     "test-coverage": [
       "phpunit --testsuite=plugin --coverage-html=tests/coverage"
     ]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c83e50efa8b4ba7ea6dc3de68354ddf5",
+    "content-hash": "57b6c3231f4d1bbfd878c50a778f2880",
     "packages": [],
     "packages-dev": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,9 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd86f99767fa5412fdd10e6971be6a34",
-    "packages": [
+    "content-hash": "c83e50efa8b4ba7ea6dc3de68354ddf5",
+    "packages": [],
+    "packages-dev": [
         {
             "name": "composer/installers",
             "version": "v1.5.0",
@@ -126,39 +127,6 @@
             ],
             "time": "2017-12-29T09:13:20+00:00"
         },
-        {
-            "name": "xrstf/composer-php52",
-            "version": "v1.0.20",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer-php52/composer-php52.git",
-                "reference": "bd41459d5e27df8d33057842b32377c39e97a5a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer-php52/composer-php52/zipball/bd41459d5e27df8d33057842b32377c39e97a5a8",
-                "reference": "bd41459d5e27df8d33057842b32377c39e97a5a8",
-                "shasum": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-default": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "xrstf\\Composer52": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "time": "2016-04-16T21:52:24+00:00"
-        }
-    ],
-    "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.4.4",
@@ -336,12 +304,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce.git",
-                "reference": "a887b49bb489852280501d1774dc05058bb47b7d"
+                "reference": "dbb6e2716d16625aab4868e6396176ccbdb040dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/a887b49bb489852280501d1774dc05058bb47b7d",
-                "reference": "a887b49bb489852280501d1774dc05058bb47b7d",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce/zipball/dbb6e2716d16625aab4868e6396176ccbdb040dd",
+                "reference": "dbb6e2716d16625aab4868e6396176ccbdb040dd",
                 "shasum": ""
             },
             "require": {
@@ -370,7 +338,7 @@
             ],
             "description": "An eCommerce toolkit that helps you sell anything. Beautifully.",
             "homepage": "https://woocommerce.com/",
-            "time": "2018-01-11T14:34:41+00:00"
+            "time": "2018-01-17T19:31:55+00:00"
         },
         {
             "name": "woocommerce/woocommerce-sniffs",

--- a/wc-custom-order-table.php
+++ b/wc-custom-order-table.php
@@ -20,10 +20,22 @@
 define( 'WC_CUSTOM_ORDER_TABLE_URL', plugin_dir_url( __FILE__ ) );
 define( 'WC_CUSTOM_ORDER_TABLE_PATH', plugin_dir_path( __FILE__ ) );
 
-/* Load includes via a PHP 5.2-compatible autoloader. */
-if ( file_exists( WC_CUSTOM_ORDER_TABLE_PATH . 'vendor/autoload_52.php' ) ) {
-	require WC_CUSTOM_ORDER_TABLE_PATH . 'vendor/autoload_52.php';
+set_include_path( get_include_path() . PATH_SEPARATOR . WC_CUSTOM_ORDER_TABLE_PATH . '/includes/' );
+
+/**
+ * Autoloader for plugin files.
+ *
+ * This autoloader operates under the assumption that class filenames use the WordPress filename
+ * conventions, where a class of 'Foo_Bar' would be named 'class-foo-bar.php'.
+ *
+ * @param string $class The class name to autoload.
+ */
+function wc_custom_order_table_autoload( $class ) {
+	$class = 'class-' . str_replace( '_', '-', $class );
+
+	return spl_autoload( $class );
 }
+spl_autoload_register( 'wc_custom_order_table_autoload' );
 
 /**
  * Install the database tables upon plugin activation.

--- a/wc-custom-order-table.php
+++ b/wc-custom-order-table.php
@@ -20,7 +20,9 @@
 define( 'WC_CUSTOM_ORDER_TABLE_URL', plugin_dir_url( __FILE__ ) );
 define( 'WC_CUSTOM_ORDER_TABLE_PATH', plugin_dir_path( __FILE__ ) );
 
+// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_set_include_path
 set_include_path( get_include_path() . PATH_SEPARATOR . WC_CUSTOM_ORDER_TABLE_PATH . '/includes/' );
+// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_set_include_path
 
 /**
  * Autoloader for plugin files.


### PR DESCRIPTION
This PR removes the Composer-generated autoloader (and thus the requirement for site owners to run `composer install` to generate it) in favor of a direct [`spl_autoload()`](http://php.net/manual/en/function.spl-autoload.php) call.

Fixes #29.