### PR TITLE
Test against multiple versions of WooCommerce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,12 @@ matrix:
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - phpenv config-rm xdebug.ini
-  - bash tests/bin/install-wp-tests.sh woocommerce_test root '' localhost $WP_VERSION
-  - bash tests/bin/set-woocommerce-version.sh $WC_VERSION
   - |
     if [[ ${GITHUB_AUTH_TOKEN} != '' ]]; then
       composer config -g github-oauth.github.com $GITHUB_AUTH_TOKEN
     fi
+  - bash tests/bin/install-wp-tests.sh woocommerce_test root '' localhost $WP_VERSION
+  - bash tests/bin/set-woocommerce-version.sh $WC_VERSION
   - composer install --prefer-source
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ before_script:
   - phpenv config-rm xdebug.ini
   - bash tests/bin/install-wp-tests.sh woocommerce_test root '' localhost $WP_VERSION
   - bash tests/bin/set-woocommerce-version.sh $WC_VERSION
+  - |
+    if [[ ${GITHUB_AUTH_TOKEN} != '' ]]; then
+      composer config -g github-oauth.github.com $GITHUB_AUTH_TOKEN
+    fi
   - composer install --prefer-source
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,16 @@ matrix:
   # The following WooCommerce core test currently fails in multisite, with or without this
   # plugin being active:
   #
-  # WC_Tests_Setup_Functions::test_wizard_in_cart_payment_gateways()
+  # PHP 7.2, WP_VERSION=trunk WP_MULTISITE=1 WC_VERSION=latest
+  # - WC_Tests_Setup_Functions::test_wizard_in_cart_payment_gateways()
+  #
+  # PHP 7.1, WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
+  # - WC_Tests_CRUD_Orders::test_get_billing_email
   allow_failures:
     - php: 7.2
       env: WP_VERSION=trunk WP_MULTISITE=1 WC_VERSION=latest
+    - php: 7.1
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,15 @@ matrix:
   fast_finish: true
   include:
     - php: 7.2
-      env: WP_VERSION=trunk WP_MULTISITE=0 RUN_PHPCS=1
+      env: WP_VERSION=trunk WP_MULTISITE=0 WC_VERSION=latest RUN_PHPCS=1
     - php: 7.2
-      env: WP_VERSION=trunk WP_MULTISITE=1
+      env: WP_VERSION=trunk WP_MULTISITE=1 WC_VERSION=latest
     - php: 7.1
-      env: WP_VERSION=latest WP_MULTISITE=0
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
+    - php: 7.1
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.0
     - php: 7.0
-      env: WP_VERSION=latest WP_MULTISITE=0
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
 
   # The following WooCommerce core test currently fails in multisite, with or without this
   # plugin being active:
@@ -27,12 +29,13 @@ matrix:
   # WC_Tests_Setup_Functions::test_wizard_in_cart_payment_gateways()
   allow_failures:
     - php: 7.2
-      env: WP_VERSION=trunk WP_MULTISITE=1
+      env: WP_VERSION=trunk WP_MULTISITE=1 WC_VERSION=latest
 
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - bash tests/bin/install-wp-tests.sh woocommerce_test root '' localhost $WP_VERSION
+  - bash tests/bin/set-woocommerce-version.sh $WC_VERSION
   - composer install --prefer-source
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - phpenv config-rm xdebug.ini
   - bash tests/bin/install-wp-tests.sh woocommerce_test root '' localhost $WP_VERSION
   - bash tests/bin/set-woocommerce-version.sh $WC_VERSION
   - composer install --prefer-source

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - php: 7.1
       env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
     - php: 7.1
-      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.0
+      env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.2.6
     - php: 7.0
       env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=latest
 

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -245,6 +245,16 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 		if ( $this->creating ) {
 			$wpdb->insert( $table, $order_data ); // WPCS: DB call OK.
 
+			/*
+			 * WooCommerce prior to 3.3 lacks some necessary filters to entirely move order details
+			 * into a custom database table. If the site is running WooCommerce < 3.3.0, store the
+			 * billing email and customer ID in the post meta table as well, for backwards-compatibility.
+			 */
+			if ( version_compare( WC()->version, '3.3.0', '<' ) ) {
+				update_post_meta( $order->get_id(), '_billing_email', $order->get_billing_email() );
+				update_post_meta( $order->get_id(), '_customer_user', $order->get_customer_id() );
+			}
+
 			$this->creating = false;
 
 		} else {

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -33,7 +33,7 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 		add_filter( 'woocommerce_reports_get_order_report_query', __CLASS__ . '::filter_order_report_query' );
 
 		// Fill-in after re-indexing of billing/shipping addresses.
-		add_action( "woocommerce_rest_system_status_tool_executed", __CLASS__ . '::rest_populate_address_indexes' );
+		add_action( 'woocommerce_rest_system_status_tool_executed', __CLASS__ . '::rest_populate_address_indexes' );
 
 		// When associating previous orders with a customer based on email, update the record.
 		add_action( 'woocommerce_update_new_customer_past_order', __CLASS__ . '::update_past_customer_order', 10, 2 );
@@ -661,8 +661,8 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 				$table_alias          = 'order_parent_meta';
 				$joins['post_parent'] = true;
 			} else {
-				$table_alias          = 'order_meta';
-				$joins['post_id']     = true;
+				$table_alias      = 'order_meta';
+				$joins['post_id'] = true;
 			}
 
 			$replacements[ $table_plus_meta_value ] = $table_alias . '.' . $order_table_column;
@@ -707,10 +707,10 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 
 		$wpdb->query( 'UPDATE ' . esc_sql( $table ) . "
 			SET billing_index = CONCAT_WS( ' ', billing_first_name, billing_last_name, billing_company, billing_company, billing_address_1, billing_address_2, billing_city, billing_state, billing_postcode, billing_country, billing_email, billing_phone )
-			WHERE billing_index IS NULL OR billing_index = ''" );
+			WHERE billing_index IS NULL OR billing_index = ''" ); // WPCS: DB call ok.
 		$wpdb->query( 'UPDATE ' . esc_sql( $table ) . "
 			SET shipping_index = CONCAT_WS( ' ', shipping_first_name, shipping_last_name, shipping_company, shipping_company, shipping_address_1, shipping_address_2, shipping_city, shipping_state, shipping_postcode, shipping_country )
-			WHERE shipping_index IS NULL OR shipping_index = ''" );
+			WHERE shipping_index IS NULL OR shipping_index = ''" ); // WPCS: DB call ok.
 	}
 
 	/**

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -256,7 +256,11 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 
 		// Insert or update the database record.
 		if ( $this->creating ) {
-			$wpdb->insert( $table, $order_data ); // WPCS: DB call OK.
+			$inserted = $wpdb->insert( $table, $order_data ); // WPCS: DB call OK.
+
+			if ( 1 !== $inserted ) {
+				return;
+			}
 
 			/*
 			 * WooCommerce prior to 3.3 lacks some necessary filters to entirely move order details

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -28,6 +28,9 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 
 		// When creating a WooCommerce order data store request, filter the MySQL query.
 		add_filter( 'woocommerce_order_data_store_cpt_get_orders_query', __CLASS__ . '::filter_database_queries', 10, 2 );
+
+		// When associating previous orders with a customer based on email, update the record.
+		add_action( 'woocommerce_update_new_customer_past_order', __CLASS__ . '::update_past_customer_order', 10, 2 );
 	}
 
 	/**
@@ -569,5 +572,17 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 		remove_filter( 'posts_where', __CLASS__ . '::meta_query_where', 100, 2 );
 
 		return $where;
+	}
+
+	/**
+	 * Associate previous orders from an email address that matches that of a new customer.
+	 *
+	 * @param int     $order_id The order ID.
+	 * @param WP_User $customer The customer object.
+	 */
+	public static function update_past_customer_order( $order_id, $customer ) {
+		$order = wc_get_order( $order_id );
+		$order->set_customer_id( $customer->ID );
+		$order->save();
 	}
 }

--- a/tests/bin/set-woocommerce-version.sh
+++ b/tests/bin/set-woocommerce-version.sh
@@ -10,12 +10,8 @@ WC_VERSION=${1-latest}
 
 if [[ $WC_VERSION != 'latest' ]]; then
 	echo "Using WooCommerce version ${WC_VERSION}:"
-	composer require --dev --no-update "woocommerce/woocommerce:${WC_VERSION}"
+	composer require --dev "woocommerce/woocommerce:${WC_VERSION}"
 else
 	echo "Using WooCommerce at master."
-	composer require --dev --no-update woocommerce/woocommerce:dev-master
-fi
-
-if [[ ! $TRAVIS ]]; then
-	echo -e "\033[0;33mIt's recommended you run \`composer update\` now to apply your changes.\033[0;m"
+	composer require --dev woocommerce/woocommerce:dev-master
 fi

--- a/tests/bin/set-woocommerce-version.sh
+++ b/tests/bin/set-woocommerce-version.sh
@@ -10,8 +10,8 @@ WC_VERSION=${1-latest}
 
 if [[ $WC_VERSION != 'latest' ]]; then
 	echo "Using WooCommerce version ${WC_VERSION}:"
-	composer require --dev "woocommerce/woocommerce:${WC_VERSION}"
+	composer require --dev --prefer-source --no-suggest "woocommerce/woocommerce:${WC_VERSION}"
 else
 	echo "Using WooCommerce at master."
-	composer require --dev woocommerce/woocommerce:dev-master
+	composer require --dev --no-suggest woocommerce/woocommerce:dev-master
 fi

--- a/tests/bin/set-woocommerce-version.sh
+++ b/tests/bin/set-woocommerce-version.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Enable the version of WooCommerce used as a Composer dependency to be changed.
+#
+# Usage:
+#
+#     set-woocommerce-version.sh [version]
+
+WC_VERSION=${1-latest}
+
+if [[ $WC_VERSION != 'latest' ]]; then
+	echo "Using WooCommerce version ${WC_VERSION}:"
+	composer require --dev --no-update "woocommerce/woocommerce:${WC_VERSION}"
+else
+	echo "Using WooCommerce at master."
+	composer require --dev --no-update woocommerce/woocommerce:dev-master
+fi

--- a/tests/bin/set-woocommerce-version.sh
+++ b/tests/bin/set-woocommerce-version.sh
@@ -15,3 +15,7 @@ else
 	echo "Using WooCommerce at master."
 	composer require --dev --no-update woocommerce/woocommerce:dev-master
 fi
+
+if [[ ! $TRAVIS ]]; then
+	echo -e "\033[0;33mIt's recommended you run \`composer update\` now to apply your changes.\033[0;m"
+fi

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,11 +28,17 @@ require_once $_tests_dir . '/includes/functions.php';
 function _manually_load_plugin() {
 	require dirname( dirname( __FILE__ ) ) . '/wc-custom-order-table.php';
 
+	echo esc_html( sprintf(
+		/* Translators: %1$s is the WooCommerce release being loaded. */
+		__( 'Using WooCommerce %1$s.', 'wc-custom-order-table' ),
+		WC_VERSION
+	) ) . PHP_EOL;
+
 	WC_Custom_Order_Table_Install::activate();
 
 	add_filter( 'woocommerce_email_actions', '__return_empty_array' );
 }
-tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin', 11 );
 
 // Finally, Start up the WP testing environment.
 require_once $_bootstrap;

--- a/tests/test-cli.php
+++ b/tests/test-cli.php
@@ -96,7 +96,7 @@ class CLITest extends TestCase {
 		$index     = 0;
 
 		foreach ( $order_ids as $order_id ) {
-			$this->assertEmpty( get_post_meta( $order_id, '_billing_email', true ) );
+			$this->assertEmpty( get_post_meta( $order_id, '_billing_first_name', true ) );
 		}
 
 		$this->cli->backfill( array(), array(

--- a/tests/test-data-store.php
+++ b/tests/test-data-store.php
@@ -254,6 +254,9 @@ class DataStoreTest extends TestCase {
 		$row      = $this->get_order_row( $order->get_id() );
 		$mapping  = WC_Order_Data_Store_Custom_Table::get_postmeta_mapping();
 
+		// For versions < WooCommerce 3.3, a few fields may be set.
+		unset( $mapping['billing_email'], $mapping['customer_id'] );
+
 		foreach ( $mapping as $column => $meta_key ) {
 			$this->assertEmpty( get_post_meta( $order->get_id(), $meta_key, true ) );
 		}

--- a/wc-custom-order-table.php
+++ b/wc-custom-order-table.php
@@ -9,8 +9,8 @@
  * License:              GPL2
  * License URI:          https://www.gnu.org/licenses/gpl-2.0.html
  *
- * WC requires at least: 3.0.0
- * WC tested up to:      3.2.6
+ * WC requires at least: 3.2.6
+ * WC tested up to:      3.3.0
  *
  * @package WooCommerce_Custom_Order_Tables
  * @author  Liquid Web


### PR DESCRIPTION
This PR adds the ability to have Travis run the test suite against multiple versions of WooCommerce, using the `WC_VERSION` environment variable (default is "latest", which maps to `dev-master`). Per @bswatson's recommendation, we're targeting the latest patch release of the current minor version (3.2.6 at the time of this writing).

Fixes #24.